### PR TITLE
chore: set Dependabot gomod commit prefix to fix(deps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Motivation
- Configure Dependabot to use the `fix(deps)` commit message prefix for Go module updates so generated PRs follow the desired commit message style.

### Description
- Add `commit-message: prefix: "fix(deps)"` to the `gomod` entry in `.github/dependabot.yml` to set the commit prefix for Go dependency updates.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d78d120a4832986dde59a28893bdf)