### PR TITLE
Strip path prefix from release tag before renaming Wails artifacts

### DIFF
--- a/.github/workflows/wails-release.yml
+++ b/.github/workflows/wails-release.yml
@@ -196,6 +196,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.prepare.outputs.release_tag }}"
+          tag="${tag##*/}"
           os="macos"
           dir="wails-ui/workset/build/bin"
           if [ ! -d "$dir" ]; then
@@ -246,6 +247,7 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ needs.prepare.outputs.release_tag }}"
+          $tag = Split-Path -Leaf $tag
           $os = "windows"
           $dir = "wails-ui/workset/build/bin"
           if (-not (Test-Path $dir)) {


### PR DESCRIPTION
### Motivation
- The rename step produced invalid target filenames when `release_tag` contained a path (e.g. included slashes), causing `mv`/`Move-Item` to fail. This ensures generated artifact names do not include path components.

### Description
- In the macOS `Rename artifacts` bash step, strip path prefixes from the tag with `tag="${tag##*/}"` before building the new filenames.
- In the Windows `Rename artifacts` PowerShell step, extract the tag leaf with `$tag = Split-Path -Leaf $tag` before renaming files.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef52d821c832990045477d4c05249)