### PR TITLE
Package macOS Wails app for release upload

### DIFF
--- a/.github/workflows/wails-release.yml
+++ b/.github/workflows/wails-release.yml
@@ -215,6 +215,21 @@ jobs:
             fi
             mv "$path" "$dir/$new"
           done
+      - name: Package macOS app
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="wails-ui/workset/build/bin"
+          shopt -s nullglob
+          apps=("$dir"/*.app)
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "No .app bundles found to package in $dir"
+            exit 1
+          fi
+          for app in "${apps[@]}"; do
+            zip_path="${app}.zip"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$zip_path"
+          done
       - name: Upload release assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:


### PR DESCRIPTION
### Motivation
- The GitHub release step `softprops/action-gh-release` failed to include macOS `.app` bundles because they are directories and were not packaged as files matching the workflow `files` pattern.

### Description
- Add a `Package macOS app` step to `.github/workflows/wails-release.yml` that zips any `*.app` bundles in `wails-ui/workset/build/bin` using `ditto -c -k --sequesterRsrc --keepParent`.
- The new step runs after the existing `Rename artifacts` step and before the `Upload release assets` step and exits with an error if no `.app` bundles are found.
- No other workflow behavior or platform jobs were changed.

### Testing
- No automated tests were executed because this is a CI workflow change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef746cfa483298e22d0451220d7e0)