### PR TITLE
Enable per-package release PRs and include component in release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
### Motivation
- Separate releases per package are required so `release-please` opens one PR per package and tags include the package/component for clarity.

### Description
- Added `"separate-pull-requests": true` to `release-please-config.json` to split releases into per-package PRs.
- Added `"include-component-in-tag": true` to `release-please-config.json` so release tags include the component name.
- No other configuration or code changes were made; existing package entries remain unchanged.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef7d40ab88329af6728fe35e95195)