### PR TITLE
Enable `include-component-in-tag` in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,3 +20,4 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          include-component-in-tag: true


### PR DESCRIPTION
### Motivation
- The repo config enables component tagging but the workflow did not pass the `include-component-in-tag` input to the Release Please action, causing multiple package paths to collapse into a single component and produce only one PR instead of two.

### Description
- Pass `include-component-in-tag: true` to the `googleapis/release-please-action` in `.github/workflows/release-please.yml` so the action honors component tags defined in `release-please-config.json`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696efad0640c8329b8f91b8956fab5a4)