### PR TITLE
chore(deps): add Dependabot npm updates for wails-ui frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/wails-ui/workset/frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Motivation
- Enable Dependabot to open dependency updates for the Wails UI frontend by adding an `npm` update entry so the frontend `package.json` is monitored.

### Description
- Add an `npm` `package-ecosystem` entry to `.github/dependabot.yml` targeting the `/wails-ui/workset/frontend` directory with a weekly schedule.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703e90d02c8329aa0703f237ac3b04)