### PR TITLE
feat(frontend): make terminal flush and add About section to Settings

### DIFF
--- a/wails-ui/workset/frontend/src/App.svelte
+++ b/wails-ui/workset/frontend/src/App.svelte
@@ -20,8 +20,7 @@
 	import TerminalWorkspace from './lib/components/TerminalWorkspace.svelte';
 	import WorkspaceActionModal from './lib/components/WorkspaceActionModal.svelte';
 	import WorkspaceTree from './lib/components/WorkspaceTree.svelte';
-	import { fetchAppVersion, fetchGitHubAuthInfo } from './lib/api';
-	import type { AppVersion } from './lib/types';
+	import { fetchGitHubAuthInfo } from './lib/api';
 
 	const hasWorkspace = $derived($activeWorkspace !== null);
 	const hasRepo = $derived($activeRepo !== null);
@@ -31,17 +30,7 @@
 	let actionOpen = $state(false);
 	let authModalOpen = $state(false);
 	let authModalDismissed = $state(false);
-	let appVersion = $state<AppVersion | null>(null);
-	const versionLabel = $derived(
-		appVersion
-			? `${appVersion.version}${appVersion.dirty ? '+dirty' : ''} (${appVersion.commit ? appVersion.commit.slice(0, 7) : 'unknown'})`
-			: '',
-	);
-	const versionTitle = $derived(
-		appVersion
-			? `${appVersion.version}${appVersion.dirty ? '+dirty' : ''} (${appVersion.commit || 'unknown'})`
-			: '',
-	);
+
 	let actionContext: {
 		mode: 'create' | 'rename' | 'add-repo' | 'archive' | 'remove-workspace' | 'remove-repo' | null;
 		workspaceId: string | null;
@@ -87,13 +76,6 @@
 	onMount(() => {
 		void loadWorkspaces();
 		void checkGitHubAuth();
-		void (async () => {
-			try {
-				appVersion = await fetchAppVersion();
-			} catch {
-				appVersion = null;
-			}
-		})();
 	});
 </script>
 
@@ -267,19 +249,13 @@
 			</div>
 		</div>
 	{/if}
-
-	<footer class="app-footer" aria-label="App version">
-		{#if appVersion}
-			<span class="app-version" title={versionTitle}>{versionLabel}</span>
-		{/if}
-	</footer>
 </div>
 
 <style>
 	.app {
 		height: 100vh;
 		display: grid;
-		grid-template-rows: auto 1fr auto;
+		grid-template-rows: auto 1fr;
 		overflow: hidden;
 	}
 
@@ -383,7 +359,7 @@
 	}
 
 	.main {
-		padding: 8px;
+		padding: 0;
 		overflow-x: visible;
 		overflow-y: hidden;
 		background: transparent; /* Let vibrancy show through */
@@ -505,20 +481,4 @@
 		}
 	}
 
-	.app-footer {
-		display: flex;
-		justify-content: flex-end;
-		align-items: center;
-		padding: 10px 16px;
-		border-top: 1px solid var(--border);
-		background: var(--panel);
-		color: var(--muted);
-		font-size: 12px;
-		--wails-draggable: no-drag;
-	}
-
-	.app-version {
-		font-family: var(--font-mono);
-		letter-spacing: 0.02em;
-	}
 </style>

--- a/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { fetchSettings, setDefaultSetting, restartSessiond } from '../api';
+	import { fetchSettings, setDefaultSetting, restartSessiond, fetchAppVersion } from '../api';
 	import type { SessiondStatusResponse } from '../api';
 	import type { SettingsDefaults, SettingsSnapshot } from '../types';
 	import SettingsSidebar from './settings/SettingsSidebar.svelte';
@@ -11,6 +11,7 @@
 	import AliasManager from './settings/sections/AliasManager.svelte';
 	import GroupManager from './settings/sections/GroupManager.svelte';
 	import Button from './ui/Button.svelte';
+	import type { AppVersion } from '../types';
 
 	interface Props {
 		onClose: () => void;
@@ -48,6 +49,7 @@
 	let activeSection = $state('workspace');
 	let aliasCount = $state(0);
 	let groupCount = $state(0);
+	let appVersion = $state<AppVersion | null>(null);
 
 	const formatError = (err: unknown): string => {
 		if (err instanceof Error) {
@@ -161,6 +163,13 @@
 
 	onMount(() => {
 		void loadSettings();
+		void (async () => {
+			try {
+				appVersion = await fetchAppVersion();
+			} catch {
+				appVersion = null;
+			}
+		})();
 	});
 </script>
 
@@ -203,6 +212,95 @@
 					<AliasManager onAliasCountChange={(count) => (aliasCount = count)} />
 				{:else if activeSection === 'groups'}
 					<GroupManager onGroupCountChange={(count) => (groupCount = count)} />
+				{:else if activeSection === 'about'}
+					<div class="about-section">
+						<div class="about-header">
+							<img src="images/logo.png" alt="Workset" class="about-logo" />
+							<h3>Workset</h3>
+							<p class="tagline">Workspace management for multi-repo development</p>
+						</div>
+						
+						{#if appVersion}
+							<div class="info-block">
+								<div class="version-header">
+									<h4>Version</h4>
+									<button 
+										type="button" 
+										class="copy-btn"
+										title="Copy version info"
+										onclick={async () => {
+											const versionText = `Workset ${appVersion?.version}${appVersion?.dirty ? '+dirty' : ''} (${appVersion?.commit || 'unknown'})`;
+											try {
+												if (navigator.clipboard) {
+													await navigator.clipboard.writeText(versionText);
+												}
+											} catch {
+												// Silently fail if clipboard is not available
+											}
+										}}
+									>
+										<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+											<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+										</svg>
+									</button>
+								</div>
+								<div class="version-info">
+									<div class="version-row">
+										<span class="label">Version:</span>
+										<span class="value">{appVersion.version}{appVersion.dirty ? '+dirty' : ''}</span>
+									</div>
+									{#if appVersion.commit}
+										<div class="version-row">
+											<span class="label">Commit:</span>
+											<span class="value">{appVersion.commit}</span>
+										</div>
+									{/if}
+								</div>
+								<button type="button" class="update-btn" disabled>
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+										<path d="M21 3v6h-6"/>
+										<path d="M21 3l-9 9"/>
+									</svg>
+									Check for Updates
+									<span class="coming-soon">Coming soon</span>
+								</button>
+							</div>
+						{/if}
+						
+						<div class="info-block">
+							<h4>Built With</h4>
+							<div class="tech-stack">
+								<span class="tech-badge">Wails</span>
+								<span class="tech-badge">Svelte</span>
+								<span class="tech-badge">Go</span>
+								<span class="tech-badge">TypeScript</span>
+							</div>
+						</div>
+						
+						<div class="info-block">
+							<h4>Links</h4>
+							<div class="links">
+								<a href="https://github.com/anomalyco/workset" target="_blank" rel="noopener noreferrer" class="link">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+								</svg>
+									GitHub Repository
+								</a>
+								<a href="https://github.com/anomalyco/workset/issues" target="_blank" rel="noopener noreferrer" class="link">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/>
+								</svg>
+									Report an Issue
+								</a>
+							</div>
+						</div>
+						
+						<div class="copyright">
+							© {new Date().getFullYear()} Sean Trantalis. Open source under MIT License.
+						</div>
+					</div>
 				{/if}
 			</div>
 		</div>
@@ -319,12 +417,193 @@
 		padding: var(--space-4) var(--space-6);
 		border-top: 1px solid rgba(255, 255, 255, 0.06);
 		background: var(--panel);
+		border-radius: 0;
+		max-height: 100vh;
 	}
 
-	.meta {
+	.about-section {
+		padding: 0;
+		max-width: 500px;
+		margin: 0 auto;
+	}
+
+	.about-header {
+		margin-bottom: 24px;
+		text-align: center;
+	}
+
+	.about-logo {
+		width: 48px;
+		height: 48px;
+		margin-bottom: 12px;
+		opacity: 0.9;
+	}
+
+	.about-header h3 {
+		font-size: 24px;
+		font-weight: 600;
+		margin: 0 0 6px 0;
+		color: var(--text);
+	}
+
+	.tagline {
+		font-size: 14px;
+		color: var(--muted);
+		margin: 0;
+	}
+
+	.info-block {
+		margin-bottom: 20px;
+		padding-bottom: 16px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.info-block:last-of-type {
+		border-bottom: none;
+		margin-bottom: 0;
+	}
+
+	.info-block h4 {
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--muted);
+		margin: 0 0 12px 0;
+	}
+
+	.version-header {
 		display: flex;
 		align-items: center;
-		gap: var(--space-2);
+		justify-content: space-between;
+		margin-bottom: 12px;
+	}
+
+	.version-header h4 {
+		margin: 0;
+	}
+
+	.copy-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		background: transparent;
+		color: var(--muted);
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+
+	.copy-btn:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 8%, transparent);
+	}
+
+	.update-btn {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 16px;
+		padding: 8px 16px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--panel-strong);
+		color: var(--muted);
+		font-size: 13px;
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+
+	.update-btn:disabled {
+		pointer-events: none;
+	}
+
+	.coming-soon {
+		font-size: 10px;
+		padding: 2px 6px;
+		background: var(--border);
+		border-radius: 4px;
+		margin-left: 4px;
+	}
+
+	.version-info {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.version-row {
+		display: flex;
+		gap: 12px;
+		font-size: 13px;
+	}
+
+	.version-row .label {
+		color: var(--muted);
+		min-width: 60px;
+	}
+
+	.version-row .value {
+		color: var(--text);
+		font-family: var(--font-mono);
+	}
+
+	.tech-stack {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.tech-badge {
+		padding: 4px 10px;
+		background: var(--panel-strong);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		font-size: 12px;
+		color: var(--text);
+	}
+
+	.links {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		align-items: flex-start;
+	}
+
+	.link {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 10px;
+		background: transparent;
+		border: none;
+		color: var(--text);
+		text-decoration: none;
+		font-size: 13px;
+		transition: all 0.15s ease;
+		border-radius: var(--radius-sm);
+	}
+
+	.link:hover {
+		border-color: var(--accent);
+		background: color-mix(in srgb, var(--accent) 8%, var(--panel-strong));
+	}
+
+	.link svg {
+		flex-shrink: 0;
+		opacity: 0.7;
+	}
+
+	.copyright {
+		margin-top: 16px;
+		padding-top: 12px;
+		border-top: 1px solid var(--border);
+		font-size: 12px;
+		color: var(--muted);
 	}
 
 	.config-label {

--- a/wails-ui/workset/frontend/src/lib/components/TerminalLayoutNode.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalLayoutNode.svelte
@@ -510,13 +510,13 @@
 	.split.row > .split-divider {
 		width: 1px;
 		cursor: col-resize;
-		margin: 0 4px;
+		margin: 0;
 	}
 
 	.split.column > .split-divider {
 		height: 1px;
 		cursor: row-resize;
-		margin: 4px 0;
+		margin: 0;
 	}
 
 	.split-divider:hover,
@@ -537,11 +537,11 @@
 		min-height: 0;
 		min-width: 0;
 		background: var(--panel);
-		border-radius: 12px;
+		border-radius: 0;
 		overflow: hidden;
-		border: 1px solid var(--border);
+		border: none;
 		transition: all 0.2s ease;
-		box-shadow: var(--shadow-sm);
+		box-shadow: none;
 	}
 
 	.pane.focused {
@@ -564,7 +564,7 @@
 	.pane-header {
 		display: flex;
 		align-items: center;
-		padding: 6px 8px 4px;
+		padding: 4px 6px;
 		background: color-mix(in srgb, var(--panel-strong) 80%, var(--panel));
 		transition: background 0.2s ease;
 		border-bottom: 1px solid var(--border);
@@ -692,7 +692,7 @@
 	.pane-body {
 		flex: 1;
 		min-height: 0;
-		padding: 2px;
+		padding: 0;
 		position: relative;
 	}
 

--- a/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
@@ -2141,13 +2141,13 @@
 
 	.terminal-body {
 		background: var(--panel);
-		border: 1px solid var(--border);
-		border-radius: 12px;
-		padding: 2px;
+		border: none;
+		border-radius: 0;
+		padding: 0;
 		flex: 1;
 		display: flex;
 		flex-direction: column;
-		gap: 4px;
+		gap: 0;
 		min-height: 0;
 	}
 
@@ -2158,8 +2158,8 @@
 	}
 
 	.terminal.compact .terminal-body {
-		padding: 2px;
-		border-radius: 10px;
+		padding: 0;
+		border-radius: 0;
 	}
 
 	.daemon-status {
@@ -2335,21 +2335,11 @@
 
 	:global(.terminal-instance .xterm-viewport) {
 		background: transparent;
-		scrollbar-width: thin;
-		scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+		scrollbar-width: none;
 	}
 
 	:global(.terminal-instance .xterm-viewport::-webkit-scrollbar) {
-		width: 8px;
-	}
-
-	:global(.terminal-instance .xterm-viewport::-webkit-scrollbar-track) {
-		background: transparent;
-	}
-
-	:global(.terminal-instance .xterm-viewport::-webkit-scrollbar-thumb) {
-		background: rgba(255, 255, 255, 0.18);
-		border-radius: 6px;
+		display: none;
 	}
 
 	:global(.terminal-instance .kitty-overlay) {

--- a/wails-ui/workset/frontend/src/lib/components/TerminalWorkspace.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalWorkspace.svelte
@@ -637,8 +637,8 @@
 		flex: 1;
 		min-height: 0;
 		display: flex;
-		border: 1px solid var(--border);
-		border-radius: 10px;
+		border: none;
+		border-radius: 0;
 		background: var(--panel);
 		overflow: hidden;
 	}

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
@@ -1,0 +1,299 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import SettingsPanel from '../SettingsPanel.svelte';
+import * as api from '../../api';
+
+// Mock the API module
+vi.mock('../../api', () => ({
+	fetchSettings: vi.fn(),
+	fetchAppVersion: vi.fn(),
+	setDefaultSetting: vi.fn(),
+	restartSessiond: vi.fn(),
+}));
+
+describe('SettingsPanel About Section', () => {
+	const mockOnClose = vi.fn();
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	const waitForLoadingAndClickAbout = async (getByText: any, queryByText: any) => {
+		// Wait for loading to finish
+		await waitFor(() => {
+			expect(queryByText('Loading settings...')).not.toBeInTheDocument();
+		});
+
+		// Wait for About button to appear in sidebar
+		await waitFor(() => {
+			expect(getByText('About')).toBeInTheDocument();
+		});
+
+		// Click on About
+		const aboutButton = getByText('About');
+		await fireEvent.click(aboutButton);
+
+		// Wait for About content to render
+		await waitFor(() => {
+			expect(getByText('Workset')).toBeInTheDocument();
+		});
+	};
+
+	test('renders About section when about is selected', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check About section content
+		expect(getByText('Workspace management for multi-repo development')).toBeInTheDocument();
+		expect(getByText('Version')).toBeInTheDocument();
+		expect(getByText('Built With')).toBeInTheDocument();
+		expect(getByText('Links')).toBeInTheDocument();
+	});
+
+	test('displays version information correctly', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.2.3',
+			commit: 'def456',
+			dirty: true,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check version info
+		expect(getByText('1.2.3+dirty')).toBeInTheDocument();
+		expect(getByText('def456')).toBeInTheDocument();
+	});
+
+	test('displays version as dev when version is dev', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: 'dev',
+			commit: '',
+			dirty: false,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check dev version is displayed
+		expect(getByText('dev')).toBeInTheDocument();
+	});
+
+	test('renders About section even when version fetch fails', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockRejectedValue(new Error('Failed to fetch'));
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		// Wait for loading to finish
+		await waitFor(() => {
+			expect(queryByText('Loading settings...')).not.toBeInTheDocument();
+		});
+
+		// Wait for About button to appear in sidebar
+		await waitFor(() => {
+			expect(getByText('About')).toBeInTheDocument();
+		});
+
+		// Click on About
+		const aboutButton = getByText('About');
+		await fireEvent.click(aboutButton);
+
+		// About section should still render even without version info
+		// Look for elements that are always present (Built With section)
+		await waitFor(() => {
+			expect(getByText('Built With')).toBeInTheDocument();
+		});
+		
+		// Version section should NOT be present when appVersion is null
+		expect(queryByText('Version')).not.toBeInTheDocument();
+	});
+
+	test('displays tech stack badges', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check tech badges
+		expect(getByText('Wails')).toBeInTheDocument();
+		expect(getByText('Svelte')).toBeInTheDocument();
+		expect(getByText('Go')).toBeInTheDocument();
+		expect(getByText('TypeScript')).toBeInTheDocument();
+	});
+
+	test('displays GitHub links', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check links
+		expect(getByText('GitHub Repository')).toBeInTheDocument();
+		expect(getByText('Report an Issue')).toBeInTheDocument();
+	});
+
+	test('copy button copies version info to clipboard', async () => {
+		const clipboardWriteText = vi.fn();
+		Object.assign(navigator, {
+			clipboard: {
+				writeText: clipboardWriteText,
+			},
+		});
+
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+
+		const { getByText, getByTitle, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Click copy button
+		const copyButton = getByTitle('Copy version info');
+		await fireEvent.click(copyButton);
+
+		expect(clipboardWriteText).toHaveBeenCalledWith('Workset 1.0.0 (abc123)');
+	});
+
+	test('displays copyright with current year', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: {
+				workspace: 'test',
+				agent: 'default',
+				terminalRenderer: 'auto',
+			},
+		});
+
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		// Check copyright with current year
+		const currentYear = new Date().getFullYear();
+		expect(getByText(`© ${currentYear} Sean Trantalis. Open source under MIT License.`)).toBeInTheDocument();
+	});
+});

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.spec.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import SettingsSidebar from './SettingsSidebar.svelte';
+
+describe('SettingsSidebar', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test('renders all section groups including INFO', () => {
+		const { getByText } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'workspace',
+				onSelectSection: () => {},
+				aliasCount: 0,
+				groupCount: 0,
+			},
+		});
+
+		// Check all group titles are present
+		expect(getByText('GENERAL')).toBeInTheDocument();
+		expect(getByText('INTEGRATIONS')).toBeInTheDocument();
+		expect(getByText('LIBRARY')).toBeInTheDocument();
+		expect(getByText('INFO')).toBeInTheDocument();
+	});
+
+	test('renders About item in INFO section', () => {
+		const { getByText } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'workspace',
+				onSelectSection: () => {},
+				aliasCount: 0,
+				groupCount: 0,
+			},
+		});
+
+		expect(getByText('About')).toBeInTheDocument();
+	});
+
+	test('renders all navigation items', () => {
+		const { getByText } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'workspace',
+				onSelectSection: () => {},
+				aliasCount: 0,
+				groupCount: 0,
+			},
+		});
+
+		// GENERAL items
+		expect(getByText('Workspace')).toBeInTheDocument();
+		expect(getByText('Agent')).toBeInTheDocument();
+		expect(getByText('Terminal')).toBeInTheDocument();
+
+		// INTEGRATIONS items
+		expect(getByText('GitHub')).toBeInTheDocument();
+
+		// LIBRARY items
+		expect(getByText('Aliases')).toBeInTheDocument();
+		expect(getByText('Groups')).toBeInTheDocument();
+
+		// INFO items
+		expect(getByText('About')).toBeInTheDocument();
+	});
+
+	test('displays badge counts for aliases and groups', () => {
+		const { getByText } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'workspace',
+				onSelectSection: () => {},
+				aliasCount: 5,
+				groupCount: 3,
+			},
+		});
+
+		expect(getByText('5')).toBeInTheDocument();
+		expect(getByText('3')).toBeInTheDocument();
+	});
+
+	test('marks active section', () => {
+		const { container } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'about',
+				onSelectSection: () => {},
+				aliasCount: 0,
+				groupCount: 0,
+			},
+		});
+
+		const aboutButton = container.querySelector('button.item.active');
+		expect(aboutButton).toBeInTheDocument();
+		expect(aboutButton?.textContent).toContain('About');
+	});
+
+	test('calls onSelectSection when item is clicked', async () => {
+		const handleSelect = vi.fn();
+		const { getByText } = render(SettingsSidebar, {
+			props: {
+				activeSection: 'workspace',
+				onSelectSection: handleSelect,
+				aliasCount: 0,
+				groupCount: 0,
+			},
+		});
+
+		const aboutButton = getByText('About');
+		await fireEvent.click(aboutButton);
+
+		expect(handleSelect).toHaveBeenCalledWith('about');
+	});
+});

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
@@ -39,6 +39,10 @@
 				{ id: 'groups', label: 'Groups', count: groupCount },
 			],
 		},
+		{
+			title: 'INFO',
+			items: [{ id: 'about', label: 'About' }],
+		},
 	] as SidebarGroup[]);
 </script>
 


### PR DESCRIPTION
Terminal layout improvements:
- Remove padding from .main container (App.svelte)
- Remove borders and border-radius from workspace-container
- Remove padding from pane-body and borders from panes
- Remove margins from split dividers
- Remove footer from App.svelte to maximize terminal space
- Hide xterm scrollbar for cleaner look

Settings About section:
- Add INFO group with About item to SettingsSidebar
- Add comprehensive About section to SettingsPanel
- Display version info with copy-to-clipboard button
- Show tech stack badges (Wails, Svelte, Go, TypeScript)
- Add GitHub repository and Report Issue links
- Include copyright notice

Test coverage:
- Add SettingsSidebar.spec.ts with 6 tests
- Add SettingsPanel.about.spec.ts with 8 tests