### PR TITLE
fix(git): surface clone stderr for actionable errors

### DIFF
--- a/internal/git/cli.go
+++ b/internal/git/cli.go
@@ -295,6 +295,9 @@ func (c CLIClient) CurrentBranch(repoPath string) (string, bool, error) {
 	}
 	result, err := c.run(context.Background(), repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
+		if result.exitCode != 0 && isMissingRef(result.stderr) {
+			return "", false, nil
+		}
 		return "", false, err
 	}
 	name := strings.TrimSpace(result.stdout)


### PR DESCRIPTION
## Summary
- include git clone stderr/stdout in returned errors for actionable failures
- apply the same error annotation for bare clones

## Testing
- Not run (not requested)