### PR TITLE
ui: reduce banner height and tighten sidebar layout

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/RepoDiff.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/RepoDiff.spec.ts
@@ -80,7 +80,7 @@ beforeEach(async () => {
 		behind: 0,
 		currentBranch: 'main',
 	});
-});
+}, 30000);
 
 afterEach(() => {
 	cleanup();

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
@@ -32,6 +32,7 @@ describe('SettingsPanel About Section', () => {
 		sessionTmuxRight: '',
 		sessionScreenHard: '',
 		agent: 'default',
+		agentLaunch: '',
 		terminalIdleTimeout: '0',
 		terminalProtocolLog: 'off',
 	};

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/SessionDefaults.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/SessionDefaults.spec.ts
@@ -20,6 +20,7 @@ const buildDefaults = (): SettingsDefaults => ({
 	workspaceRoot: '/workspaces',
 	repoStoreRoot: '/repos',
 	agent: 'default',
+	agentLaunch: '',
 	terminalIdleTimeout: '0',
 	terminalProtocolLog: 'off',
 });

--- a/wails-ui/workset/main.go
+++ b/wails-ui/workset/main.go
@@ -28,7 +28,7 @@ func main() {
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,
 		Mac: &mac.Options{
-			TitleBar:   mac.TitleBarHiddenInset(),
+			TitleBar:   mac.TitleBarHidden(),
 			Appearance: mac.NSAppearanceNameDarkAqua,
 		},
 		Bind: []interface{}{


### PR DESCRIPTION
Hi Sean,

**Summary**
- Move the sidebar into the app-level grid with a new main-area wrapper and collapsed grid columns.
- Shrink the topbar/settings button styling and adjust repo-view background treatments.
- Hide the macOS title bar and load RepoDiff check annotations on demand.
- Update settings defaults specs to include `agentLaunch`.

**Testing**
- Not run (not requested).