### PR TITLE
fix(modal): size workspace action modal by mode and tighten delete confirms

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/WorkspaceActionModal.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/WorkspaceActionModal.svelte
@@ -231,11 +231,11 @@
 	let removeRepoStatusRefreshing = $state(false);
 
 	const removeConfirmValid = $derived(
-		!removeDeleteFiles || removeConfirmText.trim().toUpperCase() === 'DELETE',
+		!removeDeleteFiles || removeConfirmText === 'DELETE',
 	);
 	const removeRepoConfirmRequired = $derived(removeDeleteWorktree);
 	const removeRepoConfirmValid = $derived(
-		!removeRepoConfirmRequired || removeRepoConfirmText.trim().toUpperCase() === 'DELETE',
+		!removeRepoConfirmRequired || removeRepoConfirmText === 'DELETE',
 	);
 	const removeRepoStatus = $derived(
 		workspaceId && repoName
@@ -285,6 +285,10 @@
 							: mode === 'remove-repo'
 								? 'Remove repo'
 								: 'Workspace action',
+	);
+
+	const modalSize = $derived(
+		mode === 'create' || mode === 'add-repo' ? 'wide' : 'md',
 	);
 
 	const formatError = (err: unknown, fallback: string): string => {
@@ -528,7 +532,7 @@
 <Modal
 	title={modeTitle}
 	subtitle={mode === 'create' ? '' : (workspace?.name ?? '')}
-	size="wide"
+	size={modalSize}
 	headerAlign="left"
 	{onClose}
 	disableClose={removing}

--- a/wails-ui/workset/go.mod
+++ b/wails-ui/workset/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
 	github.com/knadh/koanf/providers/file v1.2.1 // indirect
+	github.com/knadh/koanf/providers/rawbytes v1.0.0 // indirect
 	github.com/knadh/koanf/v2 v2.3.2 // indirect
 	github.com/labstack/echo/v4 v4.13.3 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect

--- a/wails-ui/workset/go.sum
+++ b/wails-ui/workset/go.sum
@@ -51,6 +51,8 @@ github.com/knadh/koanf/providers/confmap v1.0.0 h1:mHKLJTE7iXEys6deO5p6olAiZdG5z
 github.com/knadh/koanf/providers/confmap v1.0.0/go.mod h1:txHYHiI2hAtF0/0sCmcuol4IDcuQbKTybiB1nOcUo1A=
 github.com/knadh/koanf/providers/file v1.2.1 h1:bEWbtQwYrA+W2DtdBrQWyXqJaJSG3KrP3AESOJYp9wM=
 github.com/knadh/koanf/providers/file v1.2.1/go.mod h1:bp1PM5f83Q+TOUu10J/0ApLBd9uIzg+n9UgthfY+nRA=
+github.com/knadh/koanf/providers/rawbytes v1.0.0 h1:MrKDh/HksJlKJmaZjgs4r8aVBb/zsJyc/8qaSnzcdNI=
+github.com/knadh/koanf/providers/rawbytes v1.0.0/go.mod h1:KxwYJf1uezTKy6PBtfE+m725NGp4GPVA7XoNTJ/PtLo=
 github.com/knadh/koanf/v2 v2.3.2 h1:Ee6tuzQYFwcZXQpc2MiVeC6qHMandf5SMUJJNoFp/c4=
 github.com/knadh/koanf/v2 v2.3.2/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Summary
- derive modal size so only create/add-repo uses `wide`
- require exact `DELETE` for remove confirmations (no trim/uppercase)
- refresh Go module metadata in `wails-ui/workset`

## Testing
- Not run (not requested).

## Notes
- This reduces the “giant modal” footprint for non-create flows and makes destructive confirmations stricter.