### PR TITLE
feat(wails-ui): isolate dev app state and centralize service init

### DIFF
--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -4,7 +4,7 @@ description: Desktop UI for Workset with terminals, workspace management, and Gi
 
 # Desktop App
 
-Workset includes a desktop UI built with Wails (Go backend + Svelte frontend). It uses the same worksetapi service, config, and workspace state as the CLI.
+Workset includes a desktop UI built with Wails (Go backend + Svelte frontend). Production builds use the same worksetapi service, config, and workspace state as the CLI. In `wails dev`, app state is isolated under `~/.workset/dev`.
 
 ## What it does
 
@@ -24,6 +24,8 @@ wails build
 ```
 
 You'll need the Wails CLI plus Go and Node.js installed locally.
+
+Note: `wails dev` reads/writes config, workspaces, repo store, and UI state under `~/.workset/dev`.
 
 ## GitHub auth
 

--- a/wails-ui/workset/README.md
+++ b/wails-ui/workset/README.md
@@ -10,6 +10,8 @@ To run in live development mode, run `wails dev` in the project directory. This 
 with hot reload for the frontend, plus a Wails backend bridge. If you want to develop in a browser and
 have access to your Go methods, connect to http://localhost:34115.
 
+Dev mode isolates config, workspaces, repo store, and UI state under `~/.workset/dev`.
+
 ## Building
 
 To build a redistributable, production mode package, use `wails build`.

--- a/wails-ui/workset/app.go
+++ b/wails-ui/workset/app.go
@@ -27,7 +27,7 @@ type App struct {
 // NewApp creates a new App application struct
 func NewApp() *App {
 	return &App{
-		service:         worksetapi.NewService(worksetapi.Options{}),
+		service:         newWorksetService(),
 		terminals:       map[string]*terminalSession{},
 		restoredModes:   map[string]terminalModeState{},
 		sessiondStart:   &sessiondStartState{},
@@ -40,6 +40,7 @@ func NewApp() *App {
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	logRestartf("app_startup build_marker=restart-logging-v2")
+	ensureDevConfig()
 	_, _ = worksetapi.EnsureLoginEnv(ctx)
 	ensureDevSessiondSocket()
 	setSessiondPathFromCwd()

--- a/wails-ui/workset/app_diffs.go
+++ b/wails-ui/workset/app_diffs.go
@@ -46,9 +46,7 @@ func (a *App) GetRepoDiff(workspaceID, repoID string) (RepoDiffSnapshot, error) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	repoPath, err := a.resolveRepoPath(ctx, workspaceID, repoID)
 	if err != nil {
@@ -67,9 +65,7 @@ func (a *App) GetRepoDiffSummary(workspaceID, repoID string) (RepoDiffSummary, e
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	repoPath, err := a.resolveRepoPath(ctx, workspaceID, repoID)
 	if err != nil {
@@ -95,9 +91,7 @@ func (a *App) GetRepoFileDiff(workspaceID, repoID, path, prevPath, status string
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	repoPath, err := a.resolveRepoPath(ctx, workspaceID, repoID)
 	if err != nil {
@@ -614,9 +608,7 @@ func (a *App) GetBranchDiffSummary(workspaceID, repoID, base, head string) (Repo
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	repoPath, err := a.resolveRepoPath(ctx, workspaceID, repoID)
 	if err != nil {
@@ -649,9 +641,7 @@ func (a *App) GetBranchFileDiff(workspaceID, repoID, base, head, path, prevPath 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	repoPath, err := a.resolveRepoPath(ctx, workspaceID, repoID)
 	if err != nil {

--- a/wails-ui/workset/app_github.go
+++ b/wails-ui/workset/app_github.go
@@ -90,9 +90,7 @@ func (a *App) CreatePullRequest(input PullRequestCreateRequest) (worksetapi.Pull
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.PullRequestCreatedJSON{}, err
@@ -120,9 +118,7 @@ func (a *App) GetPullRequestStatus(input PullRequestStatusRequest) (PullRequestS
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return PullRequestStatusPayload{}, err
@@ -147,9 +143,7 @@ func (a *App) GetCheckAnnotations(input GetCheckAnnotationsRequest) (worksetapi.
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.GetCheckAnnotations(ctx, worksetapi.GetCheckAnnotationsInput{
 		Owner:      input.Owner,
 		Repo:       input.Repo,
@@ -162,9 +156,7 @@ func (a *App) GetTrackedPullRequest(input PullRequestTrackedRequest) (worksetapi
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.PullRequestTrackedJSON{}, err
@@ -184,9 +176,7 @@ func (a *App) GetPullRequestReviews(input PullRequestReviewsRequest) (PullReques
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return PullRequestReviewCommentsPayload{}, err
@@ -208,9 +198,7 @@ func (a *App) GeneratePullRequestText(input PullRequestGenerateRequest) (workset
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.PullRequestGeneratedJSON{}, err
@@ -230,9 +218,7 @@ func (a *App) SendPullRequestReviewsToTerminal(input PullRequestReviewsRequest) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return err
@@ -314,9 +300,7 @@ func (a *App) CommitAndPush(input CommitAndPushRequest) (worksetapi.CommitAndPus
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.CommitAndPushResultJSON{}, err
@@ -337,9 +321,7 @@ func (a *App) GetRepoLocalStatus(input RepoLocalStatusRequest) (worksetapi.RepoL
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.RepoLocalStatusJSON{}, err
@@ -359,9 +341,7 @@ func (a *App) ListRemotes(input ListRemotesRequest) ([]worksetapi.RemoteInfoJSON
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return nil, err
@@ -381,9 +361,7 @@ func (a *App) GetCurrentGitHubUser(input GitHubUserRequest) (worksetapi.GitHubUs
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.GitHubUserJSON{}, err
@@ -403,9 +381,7 @@ func (a *App) GetGitHubAuthStatus() (worksetapi.GitHubAuthStatusJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.GetGitHubAuthStatus(ctx)
 }
 
@@ -414,9 +390,7 @@ func (a *App) GetGitHubAuthInfo() (worksetapi.GitHubAuthInfoJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.GetGitHubAuthInfo(ctx)
 }
 
@@ -425,9 +399,7 @@ func (a *App) SetGitHubToken(input GitHubTokenRequest) (worksetapi.GitHubAuthSta
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.SetGitHubToken(ctx, worksetapi.GitHubTokenInput{
 		Token:  input.Token,
 		Source: input.Source,
@@ -439,9 +411,7 @@ func (a *App) SetGitHubAuthMode(input GitHubAuthModeRequest) (worksetapi.GitHubA
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.SetGitHubAuthMode(ctx, input.Mode)
 }
 
@@ -450,9 +420,7 @@ func (a *App) SetGitHubCLIPath(input GitHubCLIPathRequest) (worksetapi.GitHubAut
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.SetGitHubCLIPath(ctx, input.Path)
 }
 
@@ -461,9 +429,7 @@ func (a *App) DisconnectGitHub() error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.ClearGitHubAuth(ctx)
 }
 
@@ -472,9 +438,7 @@ func (a *App) ReplyToReviewComment(input ReplyToReviewCommentRequest) (worksetap
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.PullRequestReviewCommentJSON{}, err
@@ -498,9 +462,7 @@ func (a *App) EditReviewComment(input EditReviewCommentRequest) (worksetapi.Pull
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return worksetapi.PullRequestReviewCommentJSON{}, err
@@ -522,9 +484,7 @@ func (a *App) DeleteReviewComment(input DeleteReviewCommentRequest) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return err
@@ -542,9 +502,7 @@ func (a *App) ResolveReviewThread(input ResolveReviewThreadRequest) (bool, error
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	repoName, err := resolveRepoAlias(input.WorkspaceID, input.RepoID)
 	if err != nil {
 		return false, err

--- a/wails-ui/workset/app_manage.go
+++ b/wails-ui/workset/app_manage.go
@@ -69,9 +69,7 @@ func (a *App) CreateWorkspace(input WorkspaceCreateRequest) (WorkspaceCreateResp
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, err := a.service.CreateWorkspace(ctx, worksetapi.WorkspaceCreateInput{
 		Name:   input.Name,
@@ -101,9 +99,7 @@ func (a *App) ArchiveWorkspace(workspaceID, reason string) (worksetapi.Workspace
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, _, err := a.service.ArchiveWorkspace(ctx, worksetapi.WorkspaceSelector{Value: workspaceID}, reason)
 	return result, err
@@ -114,9 +110,7 @@ func (a *App) UnarchiveWorkspace(workspaceID string) (worksetapi.WorkspaceRefJSO
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, _, err := a.service.UnarchiveWorkspace(ctx, worksetapi.WorkspaceSelector{Value: workspaceID})
 	return result, err
@@ -127,9 +121,7 @@ func (a *App) RemoveWorkspace(input WorkspaceRemoveRequest) (worksetapi.Workspac
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, err := a.service.DeleteWorkspace(ctx, worksetapi.WorkspaceDeleteInput{
 		Selector:     worksetapi.WorkspaceSelector{Value: input.WorkspaceID},
@@ -149,9 +141,7 @@ func (a *App) RenameWorkspace(workspaceID, newName string) (worksetapi.Workspace
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, err := a.service.RenameWorkspace(ctx, worksetapi.WorkspaceRenameInput{
 		Selector: worksetapi.WorkspaceSelector{Value: workspaceID},
@@ -165,9 +155,7 @@ func (a *App) AddRepo(input RepoAddRequest) (RepoAddResponse, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	name := input.Name
 	nameSet := false
@@ -204,9 +192,7 @@ func (a *App) RemoveRepo(input RepoRemoveRequest) (worksetapi.RepoRemoveResultJS
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, err := a.service.RemoveRepo(ctx, worksetapi.RepoRemoveInput{
 		Workspace:       worksetapi.WorkspaceSelector{Value: input.WorkspaceID},
@@ -226,9 +212,7 @@ func (a *App) ListAliases() ([]worksetapi.AliasJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, err := a.service.ListAliases(ctx)
 	if err != nil {
 		return nil, err
@@ -241,9 +225,7 @@ func (a *App) CreateAlias(input AliasUpsertRequest) (worksetapi.AliasMutationRes
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.CreateAlias(ctx, worksetapi.AliasUpsertInput{
 		Name:             input.Name,
 		Source:           input.Source,
@@ -261,9 +243,7 @@ func (a *App) UpdateAlias(input AliasUpsertRequest) (worksetapi.AliasMutationRes
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.UpdateAlias(ctx, worksetapi.AliasUpsertInput{
 		Name:             input.Name,
 		Source:           input.Source,
@@ -281,9 +261,7 @@ func (a *App) DeleteAlias(name string) (worksetapi.AliasMutationResultJSON, erro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.DeleteAlias(ctx, name)
 	return result, err
 }
@@ -293,9 +271,7 @@ func (a *App) ListGroups() ([]worksetapi.GroupSummaryJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, err := a.service.ListGroups(ctx)
 	if err != nil {
 		return nil, err
@@ -308,9 +284,7 @@ func (a *App) GetGroup(name string) (worksetapi.GroupJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.GetGroup(ctx, name)
 	return result, err
 }
@@ -320,9 +294,7 @@ func (a *App) CreateGroup(input GroupUpsertRequest) (worksetapi.GroupJSON, error
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.CreateGroup(ctx, worksetapi.GroupUpsertInput{
 		Name:        input.Name,
 		Description: input.Description,
@@ -335,9 +307,7 @@ func (a *App) UpdateGroup(input GroupUpsertRequest) (worksetapi.GroupJSON, error
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.UpdateGroup(ctx, worksetapi.GroupUpsertInput{
 		Name:        input.Name,
 		Description: input.Description,
@@ -350,9 +320,7 @@ func (a *App) DeleteGroup(name string) (worksetapi.AliasMutationResultJSON, erro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.DeleteGroup(ctx, name)
 	return result, err
 }
@@ -362,9 +330,7 @@ func (a *App) AddGroupMember(input GroupMemberRequest) (worksetapi.GroupJSON, er
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.AddGroupMember(ctx, worksetapi.GroupMemberInput{
 		GroupName: input.GroupName,
 		RepoName:  input.RepoName,
@@ -377,9 +343,7 @@ func (a *App) RemoveGroupMember(input GroupMemberRequest) (worksetapi.GroupJSON,
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.RemoveGroupMember(ctx, worksetapi.GroupMemberInput{
 		GroupName: input.GroupName,
 		RepoName:  input.RepoName,
@@ -392,9 +356,7 @@ func (a *App) ApplyGroup(workspaceID, groupName string) (worksetapi.GroupApplyRe
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.ApplyGroup(ctx, worksetapi.GroupApplyInput{
 		Workspace: worksetapi.WorkspaceSelector{Value: workspaceID},
 		Name:      groupName,

--- a/wails-ui/workset/app_settings.go
+++ b/wails-ui/workset/app_settings.go
@@ -47,9 +47,7 @@ func (a *App) GetSettings() (SettingsSnapshot, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	cfg, info, err := a.service.GetConfig(ctx)
 	if err != nil {
@@ -87,9 +85,7 @@ func (a *App) SetDefaultSetting(key, value string) (worksetapi.ConfigSetResultJS
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, _, err := a.service.SetDefault(ctx, key, value)
 	return result, err
 }
@@ -99,9 +95,7 @@ func (a *App) CheckAgentStatus(input AgentCheckRequest) (worksetapi.AgentCLIStat
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.GetAgentCLIStatus(ctx, input.Agent)
 }
 
@@ -110,9 +104,7 @@ func (a *App) SetAgentCLIPath(input AgentCLIPathRequest) (worksetapi.AgentCLISta
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.SetAgentCLIPath(ctx, input.Agent, input.Path)
 }
 
@@ -121,8 +113,6 @@ func (a *App) ReloadLoginEnv() (worksetapi.EnvSnapshotResultJSON, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	return a.service.ReloadLoginEnv(ctx)
 }

--- a/wails-ui/workset/app_workspaces.go
+++ b/wails-ui/workset/app_workspaces.go
@@ -38,9 +38,7 @@ func (a *App) ListWorkspaceSnapshots(input WorkspaceSnapshotRequest) ([]Workspac
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 
 	result, err := a.service.ListWorkspaceSnapshots(ctx, worksetapi.WorkspaceSnapshotOptions{
 		IncludeArchived: input.IncludeArchived,

--- a/wails-ui/workset/dev_paths.go
+++ b/wails-ui/workset/dev_paths.go
@@ -1,0 +1,25 @@
+//go:build !dev
+// +build !dev
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/strantalis/workset/pkg/worksetapi"
+)
+
+func worksetAppDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".workset"), nil
+}
+
+func serviceOptions() worksetapi.Options {
+	return worksetapi.Options{}
+}
+
+func ensureDevConfig() {}

--- a/wails-ui/workset/dev_paths_dev.go
+++ b/wails-ui/workset/dev_paths_dev.go
@@ -1,0 +1,63 @@
+//go:build dev
+// +build dev
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/strantalis/workset/pkg/worksetapi"
+)
+
+func worksetAppDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".workset", "dev"), nil
+}
+
+func serviceOptions() worksetapi.Options {
+	dir, err := worksetAppDir()
+	if err != nil {
+		return worksetapi.Options{}
+	}
+	return worksetapi.Options{
+		ConfigPath: filepath.Join(dir, "config.yaml"),
+	}
+}
+
+func ensureDevConfig() {
+	dir, err := worksetAppDir()
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+
+	svc := worksetapi.NewService(serviceOptions())
+	ctx := context.Background()
+	cfg, info, err := svc.GetConfig(ctx)
+	if err != nil {
+		return
+	}
+
+	workspaceRoot := filepath.Join(dir, "workspaces")
+	repoStoreRoot := filepath.Join(dir, "repos")
+	if !info.Exists {
+		_, _, _ = svc.SetDefault(ctx, "defaults.workspace_root", workspaceRoot)
+		_, _, _ = svc.SetDefault(ctx, "defaults.repo_store_root", repoStoreRoot)
+		return
+	}
+
+	if strings.TrimSpace(cfg.Defaults.WorkspaceRoot) == "" {
+		_, _, _ = svc.SetDefault(ctx, "defaults.workspace_root", workspaceRoot)
+	}
+	if strings.TrimSpace(cfg.Defaults.RepoStoreRoot) == "" {
+		_, _, _ = svc.SetDefault(ctx, "defaults.repo_store_root", repoStoreRoot)
+	}
+}

--- a/wails-ui/workset/go.mod
+++ b/wails-ui/workset/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
 	github.com/knadh/koanf/providers/file v1.2.1 // indirect
+	github.com/knadh/koanf/providers/rawbytes v1.0.0 // indirect
 	github.com/knadh/koanf/v2 v2.3.2 // indirect
 	github.com/labstack/echo/v4 v4.13.3 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect

--- a/wails-ui/workset/go.sum
+++ b/wails-ui/workset/go.sum
@@ -51,6 +51,8 @@ github.com/knadh/koanf/providers/confmap v1.0.0 h1:mHKLJTE7iXEys6deO5p6olAiZdG5z
 github.com/knadh/koanf/providers/confmap v1.0.0/go.mod h1:txHYHiI2hAtF0/0sCmcuol4IDcuQbKTybiB1nOcUo1A=
 github.com/knadh/koanf/providers/file v1.2.1 h1:bEWbtQwYrA+W2DtdBrQWyXqJaJSG3KrP3AESOJYp9wM=
 github.com/knadh/koanf/providers/file v1.2.1/go.mod h1:bp1PM5f83Q+TOUu10J/0ApLBd9uIzg+n9UgthfY+nRA=
+github.com/knadh/koanf/providers/rawbytes v1.0.0 h1:MrKDh/HksJlKJmaZjgs4r8aVBb/zsJyc/8qaSnzcdNI=
+github.com/knadh/koanf/providers/rawbytes v1.0.0/go.mod h1:KxwYJf1uezTKy6PBtfE+m725NGp4GPVA7XoNTJ/PtLo=
 github.com/knadh/koanf/v2 v2.3.2 h1:Ee6tuzQYFwcZXQpc2MiVeC6qHMandf5SMUJJNoFp/c4=
 github.com/knadh/koanf/v2 v2.3.2/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/wails-ui/workset/service_helpers.go
+++ b/wails-ui/workset/service_helpers.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/strantalis/workset/pkg/worksetapi"
+
+func newWorksetService() *worksetapi.Service {
+	return worksetapi.NewService(serviceOptions())
+}
+
+func (a *App) ensureService() *worksetapi.Service {
+	if a.service == nil {
+		a.service = newWorksetService()
+	}
+	return a.service
+}

--- a/wails-ui/workset/terminal_debug.go
+++ b/wails-ui/workset/terminal_debug.go
@@ -17,11 +17,11 @@ var (
 )
 
 func terminalDebugLogPath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := worksetAppDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".workset", "terminal_debug.log"), nil
+	return filepath.Join(dir, "terminal_debug.log"), nil
 }
 
 func envTruthy(value string) bool {

--- a/wails-ui/workset/terminal_layout.go
+++ b/wails-ui/workset/terminal_layout.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/strantalis/workset/pkg/worksetapi"
 )
 
 const terminalLayoutStoreVersion = 1
@@ -124,11 +122,11 @@ func (a *App) SetWorkspaceTerminalLayout(input TerminalLayoutRequest) error {
 }
 
 func (a *App) terminalLayoutStorePath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := worksetAppDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".workset", "ui_layouts.json"), nil
+	return filepath.Join(dir, "ui_layouts.json"), nil
 }
 
 func (a *App) loadTerminalLayoutStore() (terminalLayoutStore, error) {
@@ -217,9 +215,7 @@ func (a *App) startSessionsFromLayouts(ctx context.Context, store terminalLayout
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	list, err := a.service.ListWorkspaces(ctx)
 	if err != nil {
 		return false

--- a/wails-ui/workset/terminal_manager.go
+++ b/wails-ui/workset/terminal_manager.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/strantalis/workset/pkg/sessiond"
-	"github.com/strantalis/workset/pkg/worksetapi"
 )
 
 func (a *App) StartWorkspaceTerminal(workspaceID, terminalID string) error {
@@ -461,9 +460,7 @@ func (a *App) invalidateTerminalSessions(reason string) {
 }
 
 func (a *App) resolveWorkspaceRoot(ctx context.Context, workspaceID string) (string, error) {
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	result, err := a.service.ListWorkspaces(ctx)
 	if err != nil {
 		return "", err

--- a/wails-ui/workset/terminal_state.go
+++ b/wails-ui/workset/terminal_state.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/strantalis/workset/pkg/worksetapi"
 )
 
 func (a *App) ensureIdleWatcher(session *terminalSession) {
@@ -40,9 +38,7 @@ func (a *App) terminalIdleTimeout() time.Duration {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if a.service == nil {
-		a.service = worksetapi.NewService(worksetapi.Options{})
-	}
+	a.ensureService()
 	cfg, _, err := a.service.GetConfig(ctx)
 	if err != nil {
 		return 30 * time.Minute
@@ -123,11 +119,11 @@ func (a *App) snapshotTerminalState() terminalState {
 }
 
 func (a *App) terminalStatePath() (string, error) {
-	home, err := os.UserHomeDir()
+	dir, err := worksetAppDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".workset", "ui_sessions.json"), nil
+	return filepath.Join(dir, "ui_sessions.json"), nil
 }
 
 func (a *App) restoreTerminalSessions(ctx context.Context) {


### PR DESCRIPTION
## Summary
- isolate Wails dev app state under `~/.workset/dev` and wire dev-only config defaults
- centralize workset service initialization via `ensureService`/`serviceOptions`
- update UI docs to describe dev state isolation paths

## Testing
- not run (not requested)

## Notes
- logging, terminal state, and layout files now resolve via `worksetAppDir` to honor dev isolation