### PR TITLE
feat(terminal): SRE-SHIT add VS Code-style keyboard shortcuts and mouse conveniences

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/TerminalLayoutNode.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalLayoutNode.svelte
@@ -362,6 +362,13 @@
 							e.stopPropagation();
 						}}
 						onclick={() => onSelectTab(node.id, tab.id)}
+						onauxclick={(event) => {
+							// Middle-click to close tab (VS Code style)
+							if (event.button === 1) {
+								event.preventDefault();
+								onCloseTab(node.id, tab.id);
+							}
+						}}
 						onkeydown={(event) => {
 							if (event.key === 'Enter' || event.key === ' ') {
 								event.preventDefault();


### PR DESCRIPTION
## Summary
- Add Cmd/Ctrl+W to close current tab
- Add Cmd/Ctrl+T to create new tab
- Add Cmd/Ctrl+\ to split vertically / Cmd/Ctrl+Shift+\ horizontally
- Add Cmd/Ctrl+1-9 to switch tabs by index
- Add Cmd/Ctrl+=/- to increase/decrease font size
- Add Cmd/Ctrl+0 to reset font size to default (13px)
- Add middle-click on tab to close it

## Test plan
- [ ] Verify Cmd/Ctrl+W closes current tab
- [ ] Verify Cmd/Ctrl+T opens new tab
- [ ] Verify Cmd/Ctrl+\ and Cmd/Ctrl+Shift+\ split panes
- [ ] Verify Cmd/Ctrl+1-9 switches tabs
- [ ] Verify Cmd/Ctrl+=/- changes font size
- [ ] Verify Cmd/Ctrl+0 resets font size
- [ ] Verify middle-click on tab closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)