### PR TITLE
fix(workset-ui): show current branch instead of default in sidebar

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/WorkspaceItem.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/WorkspaceItem.svelte
@@ -111,9 +111,10 @@
 	}
 
 	function formatRepoRef(repo: Repo): string {
-		if (!repo.remote && !repo.defaultBranch) return '';
-		if (repo.remote && repo.defaultBranch) return `${repo.remote}/${repo.defaultBranch}`;
-		return repo.defaultBranch ?? repo.remote ?? '';
+		const branch = repo.currentBranch ?? repo.defaultBranch;
+		if (!repo.remote && !branch) return '';
+		if (repo.remote && branch) return `${repo.remote}/${branch}`;
+		return branch ?? repo.remote ?? '';
 	}
 
 	function getRepoStatusDot(repo: Repo): { className: string; label: string; title: string } {

--- a/wails-ui/workset/frontend/src/lib/state.ts
+++ b/wails-ui/workset/frontend/src/lib/state.ts
@@ -204,6 +204,7 @@ type RepoPatch = {
 	diff?: { added: number; removed: number };
 	ahead?: number;
 	behind?: number;
+	currentBranch?: string;
 };
 
 const applyRepoPatch = (workspaceId: string, repoId: string, patch: RepoPatch): void => {
@@ -246,6 +247,10 @@ const applyRepoPatch = (workspaceId: string, repoId: string, patch: RepoPatch): 
 					updated = { ...updated, behind: patch.behind };
 					repoChanged = true;
 				}
+				if (patch.currentBranch !== undefined && updated.currentBranch !== patch.currentBranch) {
+					updated = { ...updated, currentBranch: patch.currentBranch };
+					repoChanged = true;
+				}
 				return repoChanged ? updated : repo;
 			});
 			if (!repoChanged) {
@@ -278,6 +283,7 @@ export const applyRepoLocalStatus = (
 		statusKnown: true,
 		ahead: status.ahead,
 		behind: status.behind,
+		currentBranch: status.currentBranch,
 	};
 	if (!status.hasUncommitted) {
 		patch.diff = { added: 0, removed: 0 };

--- a/wails-ui/workset/frontend/src/lib/types.ts
+++ b/wails-ui/workset/frontend/src/lib/types.ts
@@ -11,6 +11,7 @@ export type Repo = {
 	path: string;
 	remote?: string;
 	defaultBranch?: string;
+	currentBranch?: string;
 	ahead?: number;
 	behind?: number;
 	dirty: boolean;


### PR DESCRIPTION
## Summary
- Sidebar always displayed `origin/main` (the configured `defaultBranch`) even after switching branches
- The backend status poller already sends `currentBranch` every 60s, but the frontend was ignoring it
- Wire `currentBranch` through `RepoPatch` → `applyRepoLocalStatus` → `formatRepoRef` so the sidebar reflects the actual checked-out branch

## Test plan
- [ ] Switch to a feature branch in a workspace repo, verify sidebar updates from `origin/main` to `origin/feature-branch` within 60s
- [ ] Verify sidebar falls back to `origin/defaultBranch` before first status poll
- [ ] `npx vitest run src/lib/components/WorkspaceTree.spec.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)