### PR TITLE
feat(settings): collapse alias advanced fields in alias manager

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/AliasManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/AliasManager.svelte
@@ -242,28 +242,33 @@
 							<Button variant="ghost" size="sm" onclick={handleBrowseSource}>Browse</Button>
 						</div>
 					</label>
-					<label class="field">
-						<span>Remote (optional)</span>
-						<input
-							type="text"
-							bind:value={formRemote}
-							placeholder="origin"
-							autocapitalize="off"
-							autocorrect="off"
-							spellcheck="false"
-						/>
-					</label>
-					<label class="field">
-						<span>Default branch</span>
-						<input
-							type="text"
-							bind:value={formBranch}
-							placeholder="main"
-							autocapitalize="off"
-							autocorrect="off"
-							spellcheck="false"
-						/>
-					</label>
+					<details class="advanced-section">
+						<summary>Advanced</summary>
+						<div class="advanced-fields">
+							<label class="field">
+								<span>Remote (optional)</span>
+								<input
+									type="text"
+									bind:value={formRemote}
+									placeholder="origin"
+									autocapitalize="off"
+									autocorrect="off"
+									spellcheck="false"
+								/>
+							</label>
+							<label class="field">
+								<span>Default branch</span>
+								<input
+									type="text"
+									bind:value={formBranch}
+									placeholder="main"
+									autocapitalize="off"
+									autocorrect="off"
+									spellcheck="false"
+								/>
+							</label>
+						</div>
+					</details>
 				</div>
 				<div class="actions">
 					{#if !isNew && selectedAlias}
@@ -475,5 +480,45 @@
 		background: var(--panel-soft);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-md);
+	}
+
+	.advanced-section {
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--panel);
+	}
+
+	.advanced-section summary {
+		padding: var(--space-3);
+		font-size: 12px;
+		font-weight: 500;
+		color: var(--muted);
+		cursor: pointer;
+		user-select: none;
+		list-style: none;
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.advanced-section summary::-webkit-details-marker {
+		display: none;
+	}
+
+	.advanced-section summary::before {
+		content: '▸';
+		font-size: 10px;
+		transition: transform var(--transition-fast);
+	}
+
+	.advanced-section[open] summary::before {
+		transform: rotate(90deg);
+	}
+
+	.advanced-fields {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+		padding: 0 var(--space-3) var(--space-3);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Move `Remote (optional)` and `Default branch` inputs into a collapsible `Advanced` section in `AliasManager.svelte`.
- Keep existing bindings and behavior for `formRemote` and `formBranch`; this is a presentation/organization change.
- Add styles for the advanced container and summary toggle, including a custom chevron that rotates when expanded.

## Why
- Reduces default visual complexity in the alias form while keeping less-frequently used fields easily accessible.

## Testing
- Not run (diff-only PR body generation based on provided changes).