### PR TITLE
feat(hooks): bootstrap frontend deps and generate Wails bindings on worktree creation

### DIFF
--- a/.workset/hooks.yaml
+++ b/.workset/hooks.yaml
@@ -1,0 +1,11 @@
+hooks:
+  - id: bootstrap-frontend-deps
+    on: [worktree.created]
+    run: ["npm", "ci"]
+    cwd: "{repo.path}/wails-ui/workset/frontend"
+    on_error: warn
+  - id: generate-wails-bindings
+    on: [worktree.created]
+    run: ["wails", "generate", "module"]
+    cwd: "{repo.path}/wails-ui/workset"
+    on_error: warn


### PR DESCRIPTION
## Summary
- Add `.workset/hooks.yaml` with automation for new worktrees.
- Add `bootstrap-frontend-deps` hook to run `npm ci` in `wails-ui/workset/frontend` on `worktree.created`.
- Add `generate-wails-bindings` hook to run `wails generate module` in `wails-ui/workset` on `worktree.created`.
- Configure both hooks with `on_error: warn` so setup issues are surfaced without blocking worktree creation.

## Why
- Reduce manual setup steps after creating a worktree.
- Keep frontend dependencies installed and Wails bindings generated consistently across worktrees.

## Impact
- Developer-experience change only; no production runtime behavior changes.
- Hook failures are non-blocking and reported as warnings.