### PR TITLE
fix(git): detect merged content across merge strategies and harden worktree removal

### DIFF
--- a/wails-ui/workset/frontend/src/lib/api.ts
+++ b/wails-ui/workset/frontend/src/lib/api.ts
@@ -1077,7 +1077,12 @@ export async function getSkill(
 	tool: string,
 	workspaceId?: string,
 ): Promise<SkillContent> {
-	return (await WailsGetSkill({ scope, dirName, tool, workspaceId: workspaceId ?? '' })) as SkillContent;
+	return (await WailsGetSkill({
+		scope,
+		dirName,
+		tool,
+		workspaceId: workspaceId ?? '',
+	})) as SkillContent;
 }
 
 export async function saveSkill(

--- a/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
@@ -335,7 +335,13 @@
 		</div>
 	{:else if snapshot}
 		<div class="body">
-			<SettingsSidebar {activeSection} onSelectSection={selectSection} {aliasCount} {groupCount} {skillCount} />
+			<SettingsSidebar
+				{activeSection}
+				onSelectSection={selectSection}
+				{aliasCount}
+				{groupCount}
+				{skillCount}
+			/>
 
 			<div class="content">
 				{#if activeSection === 'workspace'}

--- a/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
@@ -217,7 +217,16 @@
 						onclick={handleScrollToBottom}
 						aria-label="Scroll to bottom"
 					>
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<polyline points="6 9 12 15 18 9"></polyline>
 						</svg>
 					</button>

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
@@ -7,7 +7,13 @@
 		skillCount?: number;
 	}
 
-	const { activeSection, onSelectSection, aliasCount = 0, groupCount = 0, skillCount = 0 }: Props = $props();
+	const {
+		activeSection,
+		onSelectSection,
+		aliasCount = 0,
+		groupCount = 0,
+		skillCount = 0,
+	}: Props = $props();
 
 	type SidebarItem = {
 		id: string;

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		listSkills,
-		getSkill,
-		saveSkill,
-		deleteSkill,
-		syncSkill,
-	} from '../../../api';
+	import { listSkills, getSkill, saveSkill, deleteSkill, syncSkill } from '../../../api';
 	import type { SkillInfo } from '../../../api';
 	import { activeWorkspace } from '../../../state';
 	import SettingsSection from '../SettingsSection.svelte';
@@ -294,13 +288,7 @@
 			for (const skill of skills) {
 				const toTools = availableToolsForSync(skill);
 				if (toTools.length === 0) continue;
-				await syncSkill(
-					skill.scope,
-					skill.dirName,
-					skill.tools[0],
-					toTools,
-					getWorkspaceId(),
-				);
+				await syncSkill(skill.scope, skill.dirName, skill.tools[0], toTools, getWorkspaceId());
 				synced++;
 			}
 			if (synced === 0) {
@@ -345,8 +333,15 @@
 		<div class="list-header">
 			<span class="list-count">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
 			<div class="list-actions">
-				<Button variant="primary" size="sm" onclick={handleSyncAllSkills} disabled={loading || totalUnsyncedCount === 0}>
-					{loading ? 'Syncing...' : `Sync All${totalUnsyncedCount > 0 ? ` (${totalUnsyncedCount})` : ''}`}
+				<Button
+					variant="primary"
+					size="sm"
+					onclick={handleSyncAllSkills}
+					disabled={loading || totalUnsyncedCount === 0}
+				>
+					{loading
+						? 'Syncing...'
+						: `Sync All${totalUnsyncedCount > 0 ? ` (${totalUnsyncedCount})` : ''}`}
 				</Button>
 				<Button variant="ghost" size="sm" onclick={startNew}>+ New</Button>
 			</div>
@@ -444,7 +439,14 @@
 				<div class="detail-header">
 					<span>New Skill</span>
 					<button class="close-btn" type="button" onclick={closeDetail} title="Close">
-						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
 							<path d="M18 6L6 18M6 6l12 12" />
 						</svg>
 					</button>
@@ -482,11 +484,7 @@
 					</label>
 					<label class="field">
 						<span>SKILL.md content</span>
-						<textarea
-							bind:value={formContent}
-							rows="10"
-							spellcheck="false"
-							class="content-editor"
+						<textarea bind:value={formContent} rows="10" spellcheck="false" class="content-editor"
 						></textarea>
 					</label>
 				</div>
@@ -508,7 +506,14 @@
 						{/if}
 					</div>
 					<button class="close-btn" type="button" onclick={closeDetail} title="Close">
-						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
 							<path d="M18 6L6 18M6 6l12 12" />
 						</svg>
 					</button>
@@ -532,10 +537,13 @@
 							{/if}
 						{/each}
 					</div>
-					<Button variant="ghost" size="sm" onclick={handleSync} disabled={loading}>
-						Sync
-					</Button>
-					<Button variant="primary" size="sm" onclick={handleSyncAll} disabled={loading || availableToolsForSync(selectedSkill).length === 0}>
+					<Button variant="ghost" size="sm" onclick={handleSync} disabled={loading}>Sync</Button>
+					<Button
+						variant="primary"
+						size="sm"
+						onclick={handleSyncAll}
+						disabled={loading || availableToolsForSync(selectedSkill).length === 0}
+					>
 						Sync All
 					</Button>
 				</div>
@@ -543,17 +551,11 @@
 				{#if editing}
 					<label class="field">
 						<span>SKILL.md content</span>
-						<textarea
-							bind:value={formContent}
-							rows="12"
-							spellcheck="false"
-							class="content-editor"
+						<textarea bind:value={formContent} rows="12" spellcheck="false" class="content-editor"
 						></textarea>
 					</label>
 					<div class="actions">
-						<Button variant="danger" onclick={handleDelete} disabled={loading}>
-							Delete
-						</Button>
+						<Button variant="danger" onclick={handleDelete} disabled={loading}>Delete</Button>
 						<div class="spacer"></div>
 						<Button variant="ghost" onclick={cancelEdit} disabled={loading}>Cancel</Button>
 						<Button variant="primary" onclick={handleSave} disabled={loading}>
@@ -563,9 +565,7 @@
 				{:else}
 					<div class="content-preview">{formContent}</div>
 					<div class="actions">
-						<Button variant="danger" onclick={handleDelete} disabled={loading}>
-							Delete
-						</Button>
+						<Button variant="danger" onclick={handleDelete} disabled={loading}>Delete</Button>
 						<div class="spacer"></div>
 						<Button variant="ghost" onclick={() => (editing = true)}>Edit</Button>
 					</div>


### PR DESCRIPTION
## Summary
- Improve merge-completion detection in `IsContentMerged` by adding a patch-equivalence check using `git rev-list --right-only --cherry-pick --count`, so rebased/cherry-picked branches are recognized as merged even when ancestry no longer matches.
- Keep ancestry and ref-equality checks, then fall back to existing tree-based logic when patch-id matching cannot run.
- Make `WorktreeRemove` retry once with `--force` when Git reports known removable-state errors (modified/untracked files or directory not empty).
- Improve git admin path resolution to correctly handle absolute `--git-path` outputs and normalize relative paths from the resolved worktree root.

## Tests
- Add e2e coverage for workspace removal after:
  - a no-ff merge commit into `main`
  - a rebase/cherry-pick style merge
- Add `internal/git` tests for:
  - merge-commit merge detection
  - rebase/cherry-pick merge detection
  - `WorktreeRemove` force-retry behavior

## Notes
- Includes formatting-only UI changes in Svelte/TypeScript files (no intended behavior change).