### PR TITLE
refactor(config): remove terminal_renderer setting and standardize terminal renderer to webgl

### DIFF
--- a/docs/architecture/terminal.md
+++ b/docs/architecture/terminal.md
@@ -86,7 +86,6 @@ sequenceDiagram
 ## Config knobs
 
 - `defaults.terminal_idle_timeout` controls idle shutdown (used by both the daemon and the app).
-- `defaults.terminal_renderer` selects `webgl` for xterm.js rendering.
 - `defaults.terminal_protocol_log` enables OSC/CSI/DSR protocol logging (restart daemon to apply).
 - `defaults.terminal_debug_overlay` shows the terminal debug overlay (bytes in/out, backlog, timestamps).
 - `defaults.agent` controls the default coding agent for terminal launchers and PR generation.

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,7 +44,6 @@ Remote names and default branches come from repo aliases (`repos.<name>.remote` 
 | `agent` | Default agent for PR text generation, commit messages, and the GUI terminal launcher. |
 | `agent_model` | Optional model override for PR text generation and commit messages (does not affect the terminal launcher). Examples: `gpt-5.1-codex-mini` (Codex), `haiku` (Claude). |
 | `agent_launch` | Agent launch strategy: `auto` (shell + PTY fallback) or `strict` (requires a path with directory separators in `defaults.agent` or `agent.cli_path`). |
-| `terminal_renderer` | Default GUI terminal renderer (`auto`, `webgl`, `canvas`). |
 | `terminal_idle_timeout` | Idle timeout for GUI terminals/sessiond (duration like `30m`; use `0` to disable). Default is `0`. |
 | `terminal_protocol_log` | Enable sessiond protocol logging (`on`/`off`). Requires daemon restart. |
 | `terminal_debug_overlay` | Show the terminal debug overlay (`on`/`off`). |
@@ -96,7 +95,6 @@ defaults:
   agent: codex
   # agent_model: gpt-5.1-codex-mini
   agent_launch: auto
-  terminal_renderer: auto
   terminal_idle_timeout: "0"
   terminal_protocol_log: off
   terminal_debug_overlay: off

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -33,7 +33,6 @@ The app defaults to GitHub CLI. Open Settings -> GitHub to connect via CLI or a 
 
 ## Terminal settings
 
-- `defaults.terminal_renderer` controls the xterm.js renderer (`webgl`).
 - `defaults.terminal_idle_timeout` controls idle shutdown for GUI terminals.
 - `defaults.terminal_protocol_log` enables sessiond protocol logging (restart daemon to apply).
 - `defaults.terminal_debug_overlay` shows the terminal debug overlay.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -23,7 +23,6 @@ func DefaultConfig() GlobalConfig {
 			Agent:                "codex",
 			AgentModel:           "",
 			AgentLaunch:          "auto",
-			TerminalRenderer:     "auto",
 			TerminalIdleTimeout:  "0",
 			TerminalProtocolLog:  "off",
 			TerminalDebugOverlay: "off",

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -248,7 +248,6 @@ func defaultConfigMap(defaults GlobalConfig) map[string]any {
 		"defaults.agent":                     defaults.Defaults.Agent,
 		"defaults.agent_model":               defaults.Defaults.AgentModel,
 		"defaults.agent_launch":              defaults.Defaults.AgentLaunch,
-		"defaults.terminal_renderer":         defaults.Defaults.TerminalRenderer,
 		"defaults.terminal_idle_timeout":     defaults.Defaults.TerminalIdleTimeout,
 		"defaults.terminal_protocol_log":     defaults.Defaults.TerminalProtocolLog,
 		"defaults.terminal_debug_overlay":    defaults.Defaults.TerminalDebugOverlay,
@@ -303,9 +302,6 @@ func finalizeGlobal(cfg *GlobalConfig, defaults GlobalConfig) {
 	}
 	if cfg.Defaults.AgentLaunch == "" {
 		cfg.Defaults.AgentLaunch = defaults.Defaults.AgentLaunch
-	}
-	if cfg.Defaults.TerminalRenderer == "" {
-		cfg.Defaults.TerminalRenderer = defaults.Defaults.TerminalRenderer
 	}
 	if cfg.Defaults.TerminalIdleTimeout == "" {
 		cfg.Defaults.TerminalIdleTimeout = defaults.Defaults.TerminalIdleTimeout

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -30,9 +30,6 @@ func TestLoadGlobalDefaults(t *testing.T) {
 	if cfg.Defaults.SessionNameFormat == "" {
 		t.Fatalf("expected default session_name_format set")
 	}
-	if cfg.Defaults.TerminalRenderer == "" {
-		t.Fatalf("expected default terminal_renderer set")
-	}
 	if cfg.Defaults.TerminalIdleTimeout == "" {
 		t.Fatalf("expected default terminal_idle_timeout set")
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -16,7 +16,6 @@ type Defaults struct {
 	Agent                string              `yaml:"agent" json:"agent" mapstructure:"agent"`
 	AgentModel           string              `yaml:"agent_model" json:"agent_model" mapstructure:"agent_model"`
 	AgentLaunch          string              `yaml:"agent_launch" json:"agent_launch" mapstructure:"agent_launch"`
-	TerminalRenderer     string              `yaml:"terminal_renderer" json:"terminal_renderer" mapstructure:"terminal_renderer"`
 	TerminalIdleTimeout  string              `yaml:"terminal_idle_timeout" json:"terminal_idle_timeout" mapstructure:"terminal_idle_timeout"`
 	TerminalProtocolLog  string              `yaml:"terminal_protocol_log" json:"terminal_protocol_log" mapstructure:"terminal_protocol_log"`
 	TerminalDebugOverlay string              `yaml:"terminal_debug_overlay" json:"terminal_debug_overlay" mapstructure:"terminal_debug_overlay"`

--- a/pkg/worksetapi/config_service.go
+++ b/pkg/worksetapi/config_service.go
@@ -3,7 +3,6 @@ package worksetapi
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/strantalis/workset/internal/config"
 	"github.com/strantalis/workset/internal/session"
@@ -67,14 +66,6 @@ func setGlobalDefault(cfg *config.GlobalConfig, key, value string) error {
 			return fmt.Errorf("unsupported agent launch mode %q", value)
 		}
 		cfg.Defaults.AgentLaunch = mode
-	case "defaults.terminal_renderer":
-		renderer := strings.ToLower(strings.TrimSpace(value))
-		switch renderer {
-		case "auto", "webgl", "canvas":
-			cfg.Defaults.TerminalRenderer = renderer
-		default:
-			return fmt.Errorf("unsupported terminal renderer %q", value)
-		}
 	case "defaults.terminal_idle_timeout":
 		cfg.Defaults.TerminalIdleTimeout = value
 	case "defaults.terminal_protocol_log":

--- a/pkg/worksetapi/config_service_more_test.go
+++ b/pkg/worksetapi/config_service_more_test.go
@@ -29,9 +29,6 @@ func TestGetConfig(t *testing.T) {
 	if cfg.Defaults.AgentLaunch != "auto" {
 		t.Fatalf("unexpected agent launch default: %q", cfg.Defaults.AgentLaunch)
 	}
-	if cfg.Defaults.TerminalRenderer != "auto" {
-		t.Fatalf("unexpected terminal renderer default: %q", cfg.Defaults.TerminalRenderer)
-	}
 	if cfg.Defaults.TerminalIdleTimeout == "" {
 		t.Fatalf("unexpected terminal idle timeout default: %q", cfg.Defaults.TerminalIdleTimeout)
 	}
@@ -101,7 +98,6 @@ func TestSetDefaultVariousKeys(t *testing.T) {
 		"defaults.agent":                     "codex",
 		"defaults.agent_model":               "gpt-4o-mini",
 		"defaults.agent_launch":              "strict",
-		"defaults.terminal_renderer":         "webgl",
 		"defaults.terminal_idle_timeout":     "0",
 		"defaults.terminal_protocol_log":     "on",
 		"defaults.terminal_debug_overlay":    "off",
@@ -126,9 +122,6 @@ func TestSetDefaultVariousKeys(t *testing.T) {
 	}
 	if cfg.Defaults.AgentLaunch != "strict" {
 		t.Fatalf("agent launch default not set")
-	}
-	if cfg.Defaults.TerminalRenderer != "webgl" {
-		t.Fatalf("terminal renderer default not set")
 	}
 	if cfg.Defaults.TerminalIdleTimeout != "0" {
 		t.Fatalf("terminal idle timeout default not set")

--- a/wails-ui/workset/.gitignore
+++ b/wails-ui/workset/.gitignore
@@ -1,4 +1,6 @@
 build/bin
+workset
+workset.exe
 node_modules
 frontend/dist
 frontend/wailsjs/

--- a/wails-ui/workset/app_settings.go
+++ b/wails-ui/workset/app_settings.go
@@ -22,7 +22,6 @@ type SettingsDefaults struct {
 	Agent                string              `json:"agent"`
 	AgentModel           string              `json:"agentModel"`
 	AgentLaunch          string              `json:"agentLaunch"`
-	TerminalRenderer     string              `json:"terminalRenderer"`
 	TerminalIdleTimeout  string              `json:"terminalIdleTimeout"`
 	TerminalProtocolLog  string              `json:"terminalProtocolLog"`
 	TerminalDebugOverlay string              `json:"terminalDebugOverlay"`
@@ -73,7 +72,6 @@ func (a *App) GetSettings() (SettingsSnapshot, error) {
 			Agent:                cfg.Defaults.Agent,
 			AgentModel:           cfg.Defaults.AgentModel,
 			AgentLaunch:          cfg.Defaults.AgentLaunch,
-			TerminalRenderer:     cfg.Defaults.TerminalRenderer,
 			TerminalIdleTimeout:  cfg.Defaults.TerminalIdleTimeout,
 			TerminalProtocolLog:  cfg.Defaults.TerminalProtocolLog,
 			TerminalDebugOverlay: cfg.Defaults.TerminalDebugOverlay,

--- a/wails-ui/workset/frontend/src/lib/api.ts
+++ b/wails-ui/workset/frontend/src/lib/api.ts
@@ -1077,7 +1077,12 @@ export async function getSkill(
 	tool: string,
 	workspaceId?: string,
 ): Promise<SkillContent> {
-	return (await WailsGetSkill({ scope, dirName, tool, workspaceId: workspaceId ?? '' })) as SkillContent;
+	return (await WailsGetSkill({
+		scope,
+		dirName,
+		tool,
+		workspaceId: workspaceId ?? '',
+	})) as SkillContent;
 }
 
 export async function saveSkill(

--- a/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
@@ -335,7 +335,13 @@
 		</div>
 	{:else if snapshot}
 		<div class="body">
-			<SettingsSidebar {activeSection} onSelectSection={selectSection} {aliasCount} {groupCount} {skillCount} />
+			<SettingsSidebar
+				{activeSection}
+				onSelectSection={selectSection}
+				{aliasCount}
+				{groupCount}
+				{skillCount}
+			/>
 
 			<div class="content">
 				{#if activeSection === 'workspace'}

--- a/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/TerminalPane.svelte
@@ -217,7 +217,16 @@
 						onclick={handleScrollToBottom}
 						aria-label="Scroll to bottom"
 					>
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.5"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
 							<polyline points="6 9 12 15 18 9"></polyline>
 						</svg>
 					</button>

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsSidebar.svelte
@@ -7,7 +7,13 @@
 		skillCount?: number;
 	}
 
-	const { activeSection, onSelectSection, aliasCount = 0, groupCount = 0, skillCount = 0 }: Props = $props();
+	const {
+		activeSection,
+		onSelectSection,
+		aliasCount = 0,
+		groupCount = 0,
+		skillCount = 0,
+	}: Props = $props();
 
 	type SidebarItem = {
 		id: string;

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		listSkills,
-		getSkill,
-		saveSkill,
-		deleteSkill,
-		syncSkill,
-	} from '../../../api';
+	import { listSkills, getSkill, saveSkill, deleteSkill, syncSkill } from '../../../api';
 	import type { SkillInfo } from '../../../api';
 	import { activeWorkspace } from '../../../state';
 	import SettingsSection from '../SettingsSection.svelte';
@@ -294,13 +288,7 @@
 			for (const skill of skills) {
 				const toTools = availableToolsForSync(skill);
 				if (toTools.length === 0) continue;
-				await syncSkill(
-					skill.scope,
-					skill.dirName,
-					skill.tools[0],
-					toTools,
-					getWorkspaceId(),
-				);
+				await syncSkill(skill.scope, skill.dirName, skill.tools[0], toTools, getWorkspaceId());
 				synced++;
 			}
 			if (synced === 0) {
@@ -345,8 +333,15 @@
 		<div class="list-header">
 			<span class="list-count">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
 			<div class="list-actions">
-				<Button variant="primary" size="sm" onclick={handleSyncAllSkills} disabled={loading || totalUnsyncedCount === 0}>
-					{loading ? 'Syncing...' : `Sync All${totalUnsyncedCount > 0 ? ` (${totalUnsyncedCount})` : ''}`}
+				<Button
+					variant="primary"
+					size="sm"
+					onclick={handleSyncAllSkills}
+					disabled={loading || totalUnsyncedCount === 0}
+				>
+					{loading
+						? 'Syncing...'
+						: `Sync All${totalUnsyncedCount > 0 ? ` (${totalUnsyncedCount})` : ''}`}
 				</Button>
 				<Button variant="ghost" size="sm" onclick={startNew}>+ New</Button>
 			</div>
@@ -444,7 +439,14 @@
 				<div class="detail-header">
 					<span>New Skill</span>
 					<button class="close-btn" type="button" onclick={closeDetail} title="Close">
-						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
 							<path d="M18 6L6 18M6 6l12 12" />
 						</svg>
 					</button>
@@ -482,11 +484,7 @@
 					</label>
 					<label class="field">
 						<span>SKILL.md content</span>
-						<textarea
-							bind:value={formContent}
-							rows="10"
-							spellcheck="false"
-							class="content-editor"
+						<textarea bind:value={formContent} rows="10" spellcheck="false" class="content-editor"
 						></textarea>
 					</label>
 				</div>
@@ -508,7 +506,14 @@
 						{/if}
 					</div>
 					<button class="close-btn" type="button" onclick={closeDetail} title="Close">
-						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<svg
+							width="14"
+							height="14"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+						>
 							<path d="M18 6L6 18M6 6l12 12" />
 						</svg>
 					</button>
@@ -532,10 +537,13 @@
 							{/if}
 						{/each}
 					</div>
-					<Button variant="ghost" size="sm" onclick={handleSync} disabled={loading}>
-						Sync
-					</Button>
-					<Button variant="primary" size="sm" onclick={handleSyncAll} disabled={loading || availableToolsForSync(selectedSkill).length === 0}>
+					<Button variant="ghost" size="sm" onclick={handleSync} disabled={loading}>Sync</Button>
+					<Button
+						variant="primary"
+						size="sm"
+						onclick={handleSyncAll}
+						disabled={loading || availableToolsForSync(selectedSkill).length === 0}
+					>
 						Sync All
 					</Button>
 				</div>
@@ -543,17 +551,11 @@
 				{#if editing}
 					<label class="field">
 						<span>SKILL.md content</span>
-						<textarea
-							bind:value={formContent}
-							rows="12"
-							spellcheck="false"
-							class="content-editor"
+						<textarea bind:value={formContent} rows="12" spellcheck="false" class="content-editor"
 						></textarea>
 					</label>
 					<div class="actions">
-						<Button variant="danger" onclick={handleDelete} disabled={loading}>
-							Delete
-						</Button>
+						<Button variant="danger" onclick={handleDelete} disabled={loading}>Delete</Button>
 						<div class="spacer"></div>
 						<Button variant="ghost" onclick={cancelEdit} disabled={loading}>Cancel</Button>
 						<Button variant="primary" onclick={handleSave} disabled={loading}>
@@ -563,9 +565,7 @@
 				{:else}
 					<div class="content-preview">{formContent}</div>
 					<div class="actions">
-						<Button variant="danger" onclick={handleDelete} disabled={loading}>
-							Delete
-						</Button>
+						<Button variant="danger" onclick={handleDelete} disabled={loading}>Delete</Button>
 						<div class="spacer"></div>
 						<Button variant="ghost" onclick={() => (editing = true)}>Edit</Button>
 					</div>

--- a/wails-ui/workset/frontend/src/lib/terminal/terminalService.ts
+++ b/wails-ui/workset/frontend/src/lib/terminal/terminalService.ts
@@ -293,7 +293,6 @@ const resizeTimers = new Map<string, number>();
 const initTokens = new Map<string, number>();
 const startedSessions = new Set<string>();
 
-let rendererPreference = 'webgl' as const;
 let sessiondAvailable: boolean | null = null;
 let sessiondChecked = false;
 let debugEnabled = false;
@@ -1885,7 +1884,7 @@ const ensureSessionActive = async (id: string): Promise<void> => {
 				rendererMap = { ...rendererMap, [id]: 'unknown' };
 			}
 			if (!rendererModeMap[id]) {
-				rendererModeMap = { ...rendererModeMap, [id]: rendererPreference };
+				rendererModeMap = { ...rendererModeMap, [id]: 'webgl' };
 			}
 			emitState(id);
 		}
@@ -1986,7 +1985,6 @@ const ensureStream = async (id: string): Promise<void> => {
 };
 
 const loadTerminalDefaults = async (): Promise<void> => {
-	rendererPreference = 'webgl';
 	let nextDebugPreference = debugOverlayPreference;
 	try {
 		const settings = await fetchSettings();
@@ -2300,7 +2298,7 @@ const initTerminal = async (id: string): Promise<void> => {
 			rendererMap = { ...rendererMap, [id]: 'unknown' };
 		}
 		if (!rendererModeMap[id]) {
-			rendererModeMap = { ...rendererModeMap, [id]: rendererPreference };
+			rendererModeMap = { ...rendererModeMap, [id]: 'webgl' };
 		}
 		emitState(id);
 		return;
@@ -2315,7 +2313,7 @@ const initTerminal = async (id: string): Promise<void> => {
 			rendererMap = { ...rendererMap, [id]: 'unknown' };
 		}
 		if (!rendererModeMap[id]) {
-			rendererModeMap = { ...rendererModeMap, [id]: rendererPreference };
+			rendererModeMap = { ...rendererModeMap, [id]: 'webgl' };
 		}
 		inputMap = { ...inputMap, [id]: false };
 		emitState(id);


### PR DESCRIPTION
## Summary
This PR removes the configurable terminal renderer setting and standardizes GUI terminal rendering on `webgl`.

## Changes
- Removed `defaults.terminal_renderer` from config types, defaults, global config mapping, and config update validation.
- Removed related backend and API tests that asserted `terminal_renderer` behavior.
- Removed `terminalRenderer` from Wails app settings payload.
- Updated terminal frontend service to use hardcoded `webgl` renderer defaults/fallbacks instead of reading renderer preference from settings.
- Updated docs to remove references to `defaults.terminal_renderer` (`docs/config.md`, `docs/architecture/terminal.md`, `docs/desktop-app.md`).
- Minor cleanup/formatting in Svelte components and added Wails app binary artifacts to `.gitignore`.

## Migration Note
`defaults.terminal_renderer` is no longer supported. Existing config entries for this key should be removed.