### PR TITLE
feat(repo-diff): show local pending changes separately from PR files

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/RepoDiff.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/RepoDiff.svelte
@@ -1202,6 +1202,10 @@
 		return resolveBranchRefs(remotes, prStatus?.pullRequest ?? prTracked);
 	};
 
+	const shouldSplitLocalPendingSection = $derived.by(
+		() => effectiveMode === 'status' && useBranchDiff() !== null,
+	);
+
 	const loadSummary = async (): Promise<void> => {
 		if (!repoId) {
 			summary = null;
@@ -1736,7 +1740,8 @@
 							>
 								Files
 								<span class="tab-count"
-									>{(summary?.files.length ?? 0) + (localSummary?.files.length ?? 0)}</span
+									>{(summary?.files.length ?? 0) +
+										(shouldSplitLocalPendingSection ? (localSummary?.files.length ?? 0) : 0)}</span
 								>
 							</button>
 							<button
@@ -1765,7 +1770,7 @@
 					{#if sidebarTab === 'files'}
 						{#if summary && summary.files.length > 0}
 							<div class="section-title">
-								{effectiveMode === 'status' && localSummary && localSummary.files.length > 0
+								{shouldSplitLocalPendingSection && localSummary && localSummary.files.length > 0
 									? 'PR files'
 									: 'Changed files'}
 							</div>
@@ -1805,7 +1810,7 @@
 							{/each}
 						{/if}
 
-						{#if effectiveMode === 'status' && localSummary && localSummary.files.length > 0}
+						{#if shouldSplitLocalPendingSection && localSummary && localSummary.files.length > 0}
 							<div class="section-title local-section-title">Local pending changes</div>
 							{#each localSummary.files as file (`local:${file.path}:${file.prevPath ?? ''}`)}
 								<button


### PR DESCRIPTION
## Summary
- Split the Files sidebar into distinct sections when a tracked PR exists: `PR files` and `Local pending changes`.
- Render local-only changes with local-specific selection/source handling so local files open as `local` diffs instead of PR diffs.
- Fix empty-state logic to account for both PR summary and local summary, preventing false "No changes" states when only local pending files exist.
- Harden file-count/render conditions with null-safe summary access and only render PR file rows when PR summary data is present.
- Keep local-first auto-selection behavior when appropriate (no PR files selected yet and local files are available).

## Tests
- Added `RepoDiff.spec.ts` coverage for the tracked-PR + local-pending scenario.
- New test verifies the `Local pending changes` section is shown and local pending file rows are rendered separately.