### PR TITLE
feat(hooks): surface hook run feedback across CLI, API, and Wails UI

### DIFF
--- a/cmd/workset/hooks.go
+++ b/cmd/workset/hooks.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/strantalis/workset/internal/hooks"
@@ -71,26 +70,7 @@ func hooksCommand() *cli.Command {
 						})
 					}
 					styles := output.NewStyles(commandWriter(cmd), mode.Plain)
-					header := fmt.Sprintf("hooks run for %s (%s)", result.Repo, result.Event)
-					if styles.Enabled {
-						header = styles.Render(styles.Title, header)
-					}
-					if _, err := fmt.Fprintln(commandWriter(cmd), header); err != nil {
-						return err
-					}
-					for _, run := range result.Results {
-						line := fmt.Sprintf("- %s: %s", run.ID, run.Status)
-						if run.LogPath != "" {
-							line = fmt.Sprintf("%s (log: %s)", line, run.LogPath)
-						}
-						if styles.Enabled && run.Status == "ok" {
-							line = styles.Render(styles.Success, line)
-						}
-						if _, err := fmt.Fprintln(commandWriter(cmd), line); err != nil {
-							return err
-						}
-					}
-					return nil
+					return printHookRunReport(commandWriter(cmd), styles, result.Repo, result.Event, result.Results)
 				},
 			},
 		},

--- a/cmd/workset/hooks_output.go
+++ b/cmd/workset/hooks_output.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/strantalis/workset/internal/output"
+	"github.com/strantalis/workset/pkg/worksetapi"
+)
+
+func printHookRunReport(w io.Writer, styles output.Styles, repo, event string, runs []worksetapi.HookRunJSON) error {
+	header := fmt.Sprintf("hooks run for %s (%s)", repo, event)
+	if styles.Enabled {
+		header = styles.Render(styles.Title, header)
+	}
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return err
+	}
+	for _, run := range runs {
+		line := fmt.Sprintf("- %s: %s", run.ID, run.Status)
+		if run.LogPath != "" {
+			line = fmt.Sprintf("%s (log: %s)", line, run.LogPath)
+		}
+		if styles.Enabled && run.Status == worksetapi.HookRunStatusOK {
+			line = styles.Render(styles.Success, line)
+		}
+		if styles.Enabled && run.Status == worksetapi.HookRunStatusFailed {
+			line = styles.Render(styles.Error, line)
+		}
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printHookExecutionResults(w io.Writer, styles output.Styles, runs []worksetapi.HookExecutionJSON) error {
+	if len(runs) == 0 {
+		return nil
+	}
+	currentRepo := ""
+	currentEvent := ""
+	group := make([]worksetapi.HookRunJSON, 0, len(runs))
+	flush := func() error {
+		if len(group) == 0 {
+			return nil
+		}
+		if err := printHookRunReport(w, styles, currentRepo, currentEvent, group); err != nil {
+			return err
+		}
+		group = group[:0]
+		return nil
+	}
+
+	for _, run := range runs {
+		if run.Repo != currentRepo || run.Event != currentEvent {
+			if err := flush(); err != nil {
+				return err
+			}
+			currentRepo = run.Repo
+			currentEvent = run.Event
+		}
+		group = append(group, worksetapi.HookRunJSON{
+			ID:      run.ID,
+			Status:  run.Status,
+			LogPath: run.LogPath,
+		})
+	}
+	return flush()
+}

--- a/internal/hooks/observer.go
+++ b/internal/hooks/observer.go
@@ -1,0 +1,27 @@
+package hooks
+
+type HookPhase string
+
+const (
+	HookPhaseStarted  HookPhase = "started"
+	HookPhaseFinished HookPhase = "finished"
+)
+
+// HookProgress reports hook execution lifecycle updates.
+type HookProgress struct {
+	Phase         HookPhase
+	Event         Event
+	HookID        string
+	WorkspaceName string
+	RepoName      string
+	WorktreePath  string
+	Reason        string
+	Status        RunStatus
+	LogPath       string
+	Err           error
+}
+
+// RunObserver can receive live hook progress events.
+type RunObserver interface {
+	OnHookProgress(progress HookProgress)
+}

--- a/pkg/worksetapi/service.go
+++ b/pkg/worksetapi/service.go
@@ -24,8 +24,10 @@ type Options struct {
 	ExecFunc func(ctx context.Context, root string, command []string, env []string) error
 	// HookRunner overrides how hooks run commands (useful for embedding/tests).
 	HookRunner hooks.Runner
-	Clock      func() time.Time
-	Logf       func(format string, args ...any)
+	// HookObserver receives per-hook execution lifecycle updates.
+	HookObserver HookProgressObserver
+	Clock        func() time.Time
+	Logf         func(format string, args ...any)
 }
 
 // Service provides the public API for workspace, repo, alias, group, session,
@@ -39,6 +41,7 @@ type Service struct {
 	commands   CommandRunner
 	exec       func(ctx context.Context, root string, command []string, env []string) error
 	hookRunner hooks.Runner
+	hookEvents HookProgressObserver
 	clock      func() time.Time
 	logf       func(format string, args ...any)
 	github     GitHubProvider
@@ -97,6 +100,7 @@ func NewService(opts Options) *Service {
 		commands:   commandRunner,
 		exec:       execFunc,
 		hookRunner: hookRunner,
+		hookEvents: opts.HookObserver,
 		clock:      clock,
 		logf:       opts.Logf,
 		github:     githubProvider,

--- a/pkg/worksetapi/service_repos_test.go
+++ b/pkg/worksetapi/service_repos_test.go
@@ -316,6 +316,12 @@ func TestAddRepoRunsTrustedHooks(t *testing.T) {
 	if len(result.PendingHooks) != 0 {
 		t.Fatalf("expected no pending hooks")
 	}
+	if len(result.HookRuns) != 1 {
+		t.Fatalf("expected hook runs, got %d", len(result.HookRuns))
+	}
+	if result.HookRuns[0].Repo != "repo-a" || result.HookRuns[0].Event != "worktree.created" {
+		t.Fatalf("unexpected hook run payload: %+v", result.HookRuns[0])
+	}
 	if runner.calls == 0 {
 		t.Fatalf("expected hook runner to run")
 	}

--- a/pkg/worksetapi/types.go
+++ b/pkg/worksetapi/types.go
@@ -97,6 +97,7 @@ type WorkspaceCreateResult struct {
 	Workspace    WorkspaceCreatedJSON
 	Warnings     []string
 	PendingHooks []HookPending
+	HookRuns     []HookExecutionJSON
 	Config       config.GlobalConfigLoadInfo
 }
 
@@ -150,6 +151,7 @@ type RepoAddResult struct {
 	RepoDir      string
 	Warnings     []string
 	PendingHooks []HookPending
+	HookRuns     []HookExecutionJSON
 	Config       config.GlobalConfigLoadInfo
 }
 
@@ -184,6 +186,33 @@ type HookRunJSON struct {
 	ID      string        `json:"id"`
 	Status  HookRunStatus `json:"status"`
 	LogPath string        `json:"log_path,omitempty"`
+}
+
+// HookExecutionJSON reports hook execution results with repo and event context.
+type HookExecutionJSON struct {
+	Event   string        `json:"event"`
+	Repo    string        `json:"repo"`
+	ID      string        `json:"id"`
+	Status  HookRunStatus `json:"status"`
+	LogPath string        `json:"log_path,omitempty"`
+}
+
+// HookProgress describes lifecycle updates emitted while hooks run.
+type HookProgress struct {
+	Phase     string        `json:"phase"`
+	Event     string        `json:"event"`
+	Repo      string        `json:"repo"`
+	Workspace string        `json:"workspace,omitempty"`
+	HookID    string        `json:"hook_id"`
+	Reason    string        `json:"reason,omitempty"`
+	Status    HookRunStatus `json:"status,omitempty"`
+	LogPath   string        `json:"log_path,omitempty"`
+	Error     string        `json:"error,omitempty"`
+}
+
+// HookProgressObserver receives live hook lifecycle updates.
+type HookProgressObserver interface {
+	OnHookProgress(progress HookProgress)
 }
 
 type HookRunStatus string

--- a/pkg/worksetapi/workspaces.go
+++ b/pkg/worksetapi/workspaces.go
@@ -97,6 +97,7 @@ func (s *Service) CreateWorkspace(ctx context.Context, input WorkspaceCreateInpu
 	aliasUpdates := map[string]aliasUpdate{}
 	warnings := []string{}
 	pendingHooks := []HookPending{}
+	hookRuns := []HookExecutionJSON{}
 	for _, plan := range repoPlans {
 		_, resolvedRemote, repoWarnings, err := ops.AddRepo(ctx, ops.AddRepoInput{
 			WorkspaceRoot: ws.Root,
@@ -132,12 +133,15 @@ func (s *Service) CreateWorkspace(ctx context.Context, input WorkspaceCreateInpu
 		}
 		repoDir := plan.Name
 		worktreePath := workspace.RepoWorktreePath(ws.Root, ws.State.CurrentBranch, repoDir)
-		pending, hookWarnings, err := s.runWorktreeCreatedHooks(ctx, cfg, ws.Root, name, config.RepoConfig{
+		pending, runs, hookWarnings, err := s.runWorktreeCreatedHooks(ctx, cfg, ws.Root, name, config.RepoConfig{
 			Name:    plan.Name,
 			RepoDir: repoDir,
 		}, worktreePath, ws.State.CurrentBranch, "workspace.create")
 		if err != nil {
 			return WorkspaceCreateResult{}, err
+		}
+		if len(runs) > 0 {
+			hookRuns = append(hookRuns, runs...)
 		}
 		if len(hookWarnings) > 0 {
 			warnings = append(warnings, hookWarnings...)
@@ -177,7 +181,13 @@ func (s *Service) CreateWorkspace(ctx context.Context, input WorkspaceCreateInpu
 	}); err != nil {
 		return WorkspaceCreateResult{}, err
 	}
-	return WorkspaceCreateResult{Workspace: infoPayload, Warnings: warnings, PendingHooks: pendingHooks, Config: info}, nil
+	return WorkspaceCreateResult{
+		Workspace:    infoPayload,
+		Warnings:     warnings,
+		PendingHooks: pendingHooks,
+		HookRuns:     hookRuns,
+		Config:       info,
+	}, nil
 }
 
 // DeleteWorkspace removes a workspace registration or deletes files when requested.

--- a/wails-ui/workset/app.go
+++ b/wails-ui/workset/app.go
@@ -28,7 +28,7 @@ type App struct {
 // NewApp creates a new App application struct
 func NewApp() *App {
 	return &App{
-		service:          newWorksetService(),
+		service:          nil,
 		terminals:        map[string]*terminalSession{},
 		restoredModes:    map[string]terminalModeState{},
 		sessiondStart:    &sessiondStartState{},

--- a/wails-ui/workset/frontend/src/lib/api.ts
+++ b/wails-ui/workset/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
 	RepoFileDiff,
 	AgentCLIStatus,
 	EnvSnapshotResult,
+	HooksRunResponse,
 	SettingsSnapshot,
 	AppVersion,
 	Workspace,
@@ -105,6 +106,8 @@ import {
 	SaveSkill as WailsSaveSkill,
 	DeleteSkill as WailsDeleteSkill,
 	SyncSkill as WailsSyncSkill,
+	RunHooks,
+	TrustRepoHooks,
 } from '../../wailsjs/go/main/App';
 
 type WorkspaceSnapshot = {
@@ -508,6 +511,19 @@ export async function addRepo(
 	repoDir: string,
 ): Promise<RepoAddResponse> {
 	return AddRepo({ workspaceId, source, name, repoDir });
+}
+
+export async function runRepoHooks(
+	workspaceId: string,
+	repo: string,
+	event: string,
+	reason = '',
+): Promise<HooksRunResponse> {
+	return RunHooks({ workspaceId, repo, event, reason });
+}
+
+export async function trustRepoHooks(repo: string): Promise<void> {
+	await TrustRepoHooks(repo);
 }
 
 export async function removeRepo(
@@ -1077,7 +1093,12 @@ export async function getSkill(
 	tool: string,
 	workspaceId?: string,
 ): Promise<SkillContent> {
-	return (await WailsGetSkill({ scope, dirName, tool, workspaceId: workspaceId ?? '' })) as SkillContent;
+	return (await WailsGetSkill({
+		scope,
+		dirName,
+		tool,
+		workspaceId: workspaceId ?? '',
+	})) as SkillContent;
 }
 
 export async function saveSkill(

--- a/wails-ui/workset/frontend/src/lib/hookEventService.ts
+++ b/wails-ui/workset/frontend/src/lib/hookEventService.ts
@@ -1,0 +1,48 @@
+import { EventsOn } from '../../wailsjs/runtime/runtime';
+import type { HookProgressEvent } from './types';
+
+type EventHandler<T> = (payload: T) => void;
+
+type EventRegistryEntry = {
+	handlers: Set<EventHandler<unknown>>;
+	bound: boolean;
+	unsubscribe?: () => void;
+};
+
+const eventRegistry = new Map<string, EventRegistryEntry>();
+
+const subscribeEvent = <T>(event: string, handler: EventHandler<T>): (() => void) => {
+	let entry = eventRegistry.get(event);
+	if (!entry) {
+		entry = { handlers: new Set(), bound: false };
+		eventRegistry.set(event, entry);
+	}
+	entry.handlers.add(handler as EventHandler<unknown>);
+	if (!entry.bound) {
+		const unsubscribe = EventsOn(event, (payload: T) => {
+			const current = eventRegistry.get(event);
+			if (!current) return;
+			for (const registered of current.handlers) {
+				registered(payload as unknown);
+			}
+		});
+		entry.unsubscribe = unsubscribe;
+		entry.bound = true;
+	}
+	return () => {
+		const current = eventRegistry.get(event);
+		if (!current) return;
+		current.handlers.delete(handler as EventHandler<unknown>);
+		if (current.handlers.size !== 0) {
+			return;
+		}
+		if (current.bound) {
+			current.unsubscribe?.();
+		}
+		eventRegistry.delete(event);
+	};
+};
+
+export const subscribeHookProgressEvent = (
+	handler: EventHandler<HookProgressEvent>,
+): (() => void) => subscribeEvent('hooks:progress', handler);

--- a/wails-ui/workset/frontend/src/lib/types.ts
+++ b/wails-ui/workset/frontend/src/lib/types.ts
@@ -84,6 +84,7 @@ export type WorkspaceCreateResponse = {
 		status?: string;
 		reason?: string;
 	}[];
+	hookRuns?: HookExecution[];
 };
 
 export type RepoAddResponse = {
@@ -109,6 +110,38 @@ export type RepoAddResponse = {
 		status?: string;
 		reason?: string;
 	}[];
+	hookRuns?: HookExecution[];
+};
+
+export type HookExecution = {
+	event: string;
+	repo: string;
+	id: string;
+	status: string;
+	log_path?: string;
+};
+
+export type HooksRunResponse = {
+	event: string;
+	repo: string;
+	results: {
+		id: string;
+		status: string;
+		log_path?: string;
+	}[];
+};
+
+export type HookProgressEvent = {
+	operation?: string;
+	reason?: string;
+	workspace?: string;
+	repo: string;
+	event: string;
+	hookId: string;
+	phase: 'started' | 'finished';
+	status?: string;
+	logPath?: string;
+	error?: string;
 };
 
 export type RegisteredRepo = {

--- a/wails-ui/workset/hook_events.go
+++ b/wails-ui/workset/hook_events.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/strantalis/workset/pkg/worksetapi"
+	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+var hookEventsEmit = wruntime.EventsEmit
+
+type HookProgressPayload struct {
+	Operation string `json:"operation,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	Repo      string `json:"repo"`
+	Event     string `json:"event"`
+	HookID    string `json:"hookId"`
+	Phase     string `json:"phase"`
+	Status    string `json:"status,omitempty"`
+	LogPath   string `json:"logPath,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+type appHookObserver struct {
+	app *App
+}
+
+func (o appHookObserver) OnHookProgress(progress worksetapi.HookProgress) {
+	if o.app == nil || o.app.ctx == nil {
+		return
+	}
+	payload := HookProgressPayload{
+		Operation: hookOperation(progress.Reason),
+		Reason:    progress.Reason,
+		Workspace: progress.Workspace,
+		Repo:      progress.Repo,
+		Event:     progress.Event,
+		HookID:    progress.HookID,
+		Phase:     progress.Phase,
+		Status:    string(progress.Status),
+		LogPath:   progress.LogPath,
+	}
+	if progress.Error != "" {
+		payload.Error = progress.Error
+	}
+	hookEventsEmit(o.app.ctx, "hooks:progress", payload)
+}
+
+func hookOperation(reason string) string {
+	reason = strings.TrimSpace(reason)
+	switch {
+	case strings.HasPrefix(reason, "workspace.create"):
+		return "workspace.create"
+	case strings.HasPrefix(reason, "repo.add"):
+		return "repo.add"
+	case reason == "":
+		return "hooks.run"
+	default:
+		return reason
+	}
+}

--- a/wails-ui/workset/hook_events_test.go
+++ b/wails-ui/workset/hook_events_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strantalis/workset/pkg/worksetapi"
+)
+
+func TestHookOperation(t *testing.T) {
+	if got := hookOperation("workspace.create"); got != "workspace.create" {
+		t.Fatalf("unexpected operation: %s", got)
+	}
+	if got := hookOperation("repo.add.extra"); got != "repo.add" {
+		t.Fatalf("unexpected operation: %s", got)
+	}
+	if got := hookOperation(""); got != "hooks.run" {
+		t.Fatalf("unexpected operation: %s", got)
+	}
+}
+
+func TestAppHookObserverEmitsProgress(t *testing.T) {
+	origEmit := hookEventsEmit
+	defer func() {
+		hookEventsEmit = origEmit
+	}()
+
+	var (
+		eventName string
+		payload   HookProgressPayload
+	)
+	hookEventsEmit = func(_ context.Context, name string, data ...interface{}) {
+		eventName = name
+		if len(data) > 0 {
+			typed, ok := data[0].(HookProgressPayload)
+			if !ok {
+				t.Fatalf("unexpected payload type: %T", data[0])
+			}
+			payload = typed
+		}
+	}
+
+	observer := appHookObserver{app: &App{ctx: context.Background()}}
+	observer.OnHookProgress(worksetapi.HookProgress{
+		Phase:     "finished",
+		Event:     "worktree.created",
+		HookID:    "bootstrap",
+		Workspace: "demo",
+		Repo:      "repo-a",
+		Reason:    "workspace.create",
+		Status:    worksetapi.HookRunStatusFailed,
+		LogPath:   "/tmp/hook.log",
+		Error:     "boom",
+	})
+
+	if eventName != "hooks:progress" {
+		t.Fatalf("unexpected event: %s", eventName)
+	}
+	if payload.Operation != "workspace.create" {
+		t.Fatalf("unexpected operation: %s", payload.Operation)
+	}
+	if payload.Repo != "repo-a" || payload.HookID != "bootstrap" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Error == "" || payload.Status != "failed" {
+		t.Fatalf("expected error and failed status: %+v", payload)
+	}
+}

--- a/wails-ui/workset/service_helpers.go
+++ b/wails-ui/workset/service_helpers.go
@@ -2,13 +2,15 @@ package main
 
 import "github.com/strantalis/workset/pkg/worksetapi"
 
-func newWorksetService() *worksetapi.Service {
-	return worksetapi.NewService(serviceOptions())
+func newWorksetService(observer appHookObserver) *worksetapi.Service {
+	options := serviceOptions()
+	options.HookObserver = observer
+	return worksetapi.NewService(options)
 }
 
 func (a *App) ensureService() *worksetapi.Service {
 	if a.service == nil {
-		a.service = newWorksetService()
+		a.service = newWorksetService(appHookObserver{app: a})
 	}
 	return a.service
 }


### PR DESCRIPTION
## Summary
- Add hook lifecycle observation so hook runs emit started/finished progress with status, logs, and errors.
- Surface hook execution results in repo/workspace flows and standardize hook run reporting in CLI output.
- Expose hook progress and hook run actions in the Wails app so users can run/trust pending hooks from the modal.

## What changed
- `internal/hooks`: introduced `RunObserver`/`HookProgress` and emit observer callbacks from `Engine.Run`.
- `pkg/worksetapi`: wired a `HookObserver` through `Service`, added `HookExecutionJSON` and `HookRuns` on create/add results, returned executed hook runs from `runWorktreeCreatedHooks`, and added adapter/mapping helpers.
- `cmd/workset`: extracted shared hook output helpers (`printHookRunReport`, `printHookExecutionResults`), reused them in `hooks run`, `repo add`, and `workspace create`, and expanded JSON responses to include warnings + hook runs.
- `wails-ui/workset` (Go): service initialization now injects an app hook observer, added `RunHooks` and `TrustRepoHooks` app methods, and emits `hooks:progress` events.
- `wails-ui/workset/frontend`: added hook event subscription service, API wrappers, hook progress/types, and modal UX for live hook status plus run/trust actions for pending hooks.

## Test coverage
- Added engine observer assertions for start/finish event ordering and payloads.
- Added service tests confirming trusted `worktree.created` hooks execute and populate `HookRuns`.
- Added Wails hook event tests for operation mapping and progress event emission.