### PR TITLE
fix(hooks): address P1 follow-ups from #107

### DIFF
--- a/cmd/workset/repo.go
+++ b/cmd/workset/repo.go
@@ -107,6 +107,18 @@ func repoCommand() *cli.Command {
 					}
 					printConfigInfo(cmd, result)
 					mode := outputModeFromContext(cmd)
+					if mode.JSON {
+						return output.WriteJSON(commandWriter(cmd), struct {
+							worksetapi.RepoAddResultJSON
+
+							Warnings []string                       `json:"warnings,omitempty"`
+							HookRuns []worksetapi.HookExecutionJSON `json:"hook_runs,omitempty"`
+						}{
+							RepoAddResultJSON: result.Payload,
+							Warnings:          result.Warnings,
+							HookRuns:          result.HookRuns,
+						})
+					}
 					styles := output.NewStyles(commandWriter(cmd), mode.Plain)
 					if len(result.PendingHooks) > 0 && term.IsTerminal(int(os.Stdin.Fd())) {
 						for _, pending := range result.PendingHooks {
@@ -147,18 +159,6 @@ func repoCommand() *cli.Command {
 								}
 							}
 						}
-					}
-					if mode.JSON {
-						return output.WriteJSON(commandWriter(cmd), struct {
-							worksetapi.RepoAddResultJSON
-
-							Warnings []string                       `json:"warnings,omitempty"`
-							HookRuns []worksetapi.HookExecutionJSON `json:"hook_runs,omitempty"`
-						}{
-							RepoAddResultJSON: result.Payload,
-							Warnings:          result.Warnings,
-							HookRuns:          result.HookRuns,
-						})
 					}
 					msg := fmt.Sprintf("added %s to %s", result.Payload.Repo, result.Payload.Workspace)
 					if styles.Enabled {

--- a/wails-ui/workset/frontend/src/lib/components/WorkspaceActionModal.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/WorkspaceActionModal.svelte
@@ -447,12 +447,14 @@
 	};
 
 	const handleRunPendingHook = async (pending: (typeof pendingHooks)[number]): Promise<void> => {
-		if (!workspace && !workspaceId) {
-			return;
-		}
 		const targetWorkspace =
 			workspace?.id || workspaceId || hookWorkspaceId || activeHookWorkspace || '';
 		if (!targetWorkspace) {
+			pendingHooks = pendingHooks.map((entry) =>
+				entry.repo === pending.repo
+					? { ...entry, running: false, runError: 'Workspace reference unavailable for hook run.' }
+					: entry,
+			);
 			return;
 		}
 		pendingHooks = pendingHooks.map((entry) =>


### PR DESCRIPTION
Follow-up to #107 to address two P1 review items.

## Fixes
- Restore early JSON-mode return in repo up so pending-hook interactive flow never runs when --json is used.
- Ensure Wails create flow always attempts pending-hook execution (with fallback target workspace selector and explicit error when target is unavailable).

## Validation
- go test ./...
- npm run lint
- npm run check
- npm run test