### PR TITLE
fix(settings): normalize error handling and preserve update-check backend messages

### DIFF
--- a/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/SettingsPanel.svelte
@@ -27,6 +27,7 @@
 		UpdateState,
 	} from '../types';
 	import { activeWorkspace } from '../state';
+	import { toErrorMessage } from '../errors';
 	import { generateTerminalName } from '../names';
 	import SettingsSidebar from './settings/SettingsSidebar.svelte';
 	import WorkspaceDefaults from './settings/sections/WorkspaceDefaults.svelte';
@@ -90,13 +91,6 @@
 	const MIGRATION_PREFIX = 'workset:terminal-layout:migrated:v';
 	const MIGRATION_VERSION = 1;
 
-	const formatError = (err: unknown): string => {
-		if (err instanceof Error) {
-			return err.message;
-		}
-		return 'Failed to update settings.';
-	};
-
 	const buildDraft = (defaults: SettingsDefaults): void => {
 		const next: Record<FieldId, string> = {} as Record<FieldId, string>;
 		allFields.forEach((field) => {
@@ -124,7 +118,7 @@
 			snapshot = data;
 			buildDraft(data.defaults);
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'Failed to update settings.');
 		} finally {
 			loading = false;
 		}
@@ -149,7 +143,7 @@
 			try {
 				await setDefaultSetting(field.key, draft[field.id] ?? '');
 			} catch (err) {
-				error = `Failed to save: ${formatError(err)}`;
+				error = `Failed to save: ${toErrorMessage(err, 'Failed to update settings.')}`;
 				break;
 			}
 		}
@@ -189,7 +183,7 @@
 					: `Failed to restart session daemon.${warning}`;
 			}
 		} catch (err) {
-			error = `Failed to restart: ${formatError(err)}`;
+			error = `Failed to restart: ${toErrorMessage(err, 'Failed to update settings.')}`;
 		} finally {
 			restartingSessiond = false;
 		}
@@ -300,7 +294,7 @@
 			);
 			success = `Terminal layout reset for ${workspace.name}.`;
 		} catch (err) {
-			error = `Failed to reset terminal layout: ${formatError(err)}`;
+			error = `Failed to reset terminal layout: ${toErrorMessage(err, 'Failed to update settings.')}`;
 		} finally {
 			resettingTerminalLayout = false;
 		}
@@ -325,7 +319,7 @@
 			updatePreferences = await setUpdatePreferences({ channel: nextChannel });
 			updateCheck = null;
 		} catch (err) {
-			updateError = formatError(err);
+			updateError = toErrorMessage(err, 'Failed to update channel preference.');
 		}
 	};
 
@@ -337,7 +331,7 @@
 			updateCheck = await checkForUpdates(updatePreferences.channel);
 			updateState = await fetchUpdateState();
 		} catch (err) {
-			updateError = formatError(err);
+			updateError = toErrorMessage(err, 'Failed to check for updates.');
 		} finally {
 			updateBusy = false;
 		}
@@ -351,7 +345,7 @@
 			const result = await startAppUpdate(updatePreferences.channel);
 			updateState = result.state;
 		} catch (err) {
-			updateError = formatError(err);
+			updateError = toErrorMessage(err, 'Failed to start update.');
 		} finally {
 			updateBusy = false;
 		}

--- a/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
+++ b/wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts
@@ -259,6 +259,63 @@ describe('SettingsPanel About Section', () => {
 		expect(getByText('Report an Issue')).toBeInTheDocument();
 	});
 
+	test('shows backend string error when update check fails', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: buildDefaults(),
+		});
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+		vi.mocked(api.checkForUpdates).mockRejectedValue('network timeout while fetching manifest');
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		await fireEvent.click(getByText('Check for Updates'));
+
+		await waitFor(() => {
+			expect(getByText('network timeout while fetching manifest')).toBeInTheDocument();
+		});
+		expect(queryByText('Failed to update settings.')).not.toBeInTheDocument();
+	});
+
+	test('shows backend object message when update check fails', async () => {
+		vi.mocked(api.fetchSettings).mockResolvedValue({
+			configPath: '/test/config.yaml',
+			defaults: buildDefaults(),
+		});
+		vi.mocked(api.fetchAppVersion).mockResolvedValue({
+			version: '1.0.0',
+			commit: 'abc123',
+			dirty: false,
+		});
+		vi.mocked(api.checkForUpdates).mockRejectedValue({
+			message: 'updates endpoint returned 503',
+		});
+
+		const { getByText, queryByText } = render(SettingsPanel, {
+			props: {
+				onClose: mockOnClose,
+			},
+		});
+
+		await waitForLoadingAndClickAbout(getByText, queryByText);
+
+		await fireEvent.click(getByText('Check for Updates'));
+
+		await waitFor(() => {
+			expect(getByText('updates endpoint returned 503')).toBeInTheDocument();
+		});
+	});
+
 	test('copy button copies version info to clipboard', async () => {
 		const clipboardWriteText = vi.fn();
 		Object.assign(navigator, {

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/AgentDefaults.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/AgentDefaults.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import type { SettingsDefaultField } from '../../../types';
 	import type { AgentCLIStatus } from '../../../types';
+	import { toErrorMessage } from '../../../errors';
 	import SettingsSection from '../SettingsSection.svelte';
 	import Select from '../../ui/Select.svelte';
 	import Button from '../../ui/Button.svelte';
@@ -73,16 +74,6 @@
 	let envMessage = $state<string | null>(null);
 	let envError = $state<string | null>(null);
 
-	const formatError = (err: unknown, fallback: string): string => {
-		if (err instanceof Error) return err.message;
-		if (typeof err === 'string') return err;
-		if (err && typeof err === 'object' && 'message' in err) {
-			const message = (err as { message?: string }).message;
-			if (typeof message === 'string') return message;
-		}
-		return fallback;
-	};
-
 	const checkStatus = async (): Promise<void> => {
 		if (checking) return;
 		statusError = null;
@@ -99,7 +90,7 @@
 				cliPath = status.configuredPath;
 			}
 		} catch (err) {
-			statusError = formatError(err, 'Failed to check agent status.');
+			statusError = toErrorMessage(err, 'Failed to check agent status.');
 		} finally {
 			checking = false;
 		}
@@ -124,7 +115,7 @@
 			status = await setAgentCLIPath(agent, path);
 			cliPath = status?.configuredPath ?? path;
 		} catch (err) {
-			statusError = formatError(err, 'Failed to save agent CLI path.');
+			statusError = toErrorMessage(err, 'Failed to save agent CLI path.');
 		} finally {
 			savingPath = false;
 		}
@@ -139,7 +130,7 @@
 			cliPath = selected;
 			await saveCLIPath();
 		} catch (err) {
-			statusError = formatError(err, 'Failed to open file dialog.');
+			statusError = toErrorMessage(err, 'Failed to open file dialog.');
 		}
 	};
 
@@ -158,7 +149,7 @@
 				envMessage = 'Environment already up to date.';
 			}
 		} catch (err) {
-			envError = formatError(err, 'Failed to reload environment.');
+			envError = toErrorMessage(err, 'Failed to reload environment.');
 		} finally {
 			envReloading = false;
 		}

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/AliasManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/AliasManager.svelte
@@ -8,6 +8,7 @@
 		updateAlias,
 	} from '../../../api';
 	import type { Alias } from '../../../types';
+	import { toErrorMessage } from '../../../errors';
 	import SettingsSection from '../SettingsSection.svelte';
 	import Button from '../../ui/Button.svelte';
 
@@ -29,17 +30,12 @@
 	let formRemote = $state('');
 	let formBranch = $state('');
 
-	const formatError = (err: unknown): string => {
-		if (err instanceof Error) return err.message;
-		return 'An error occurred.';
-	};
-
 	const loadAliases = async (): Promise<void> => {
 		try {
 			aliases = await listAliases();
 			onAliasCountChange(aliases.length);
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 
@@ -109,7 +105,7 @@
 				selectAlias(updated);
 			}
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -134,7 +130,7 @@
 			formRemote = '';
 			formBranch = '';
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -155,7 +151,7 @@
 			if (!path) return;
 			formSource = path;
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/GitHubAuth.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/GitHubAuth.svelte
@@ -3,6 +3,7 @@
 	import Alert from '../../ui/Alert.svelte';
 	import Button from '../../ui/Button.svelte';
 	import SettingsSection from '../SettingsSection.svelte';
+	import { toErrorMessage } from '../../../errors';
 	import type { GitHubAuthInfo } from '../../../types';
 	import {
 		disconnectGitHub,
@@ -27,16 +28,6 @@
 	const login = $derived(info?.status.login ?? '');
 	const cliInstalled = $derived(info?.cli.installed ?? false);
 
-	const formatError = (err: unknown, fallback: string): string => {
-		if (err instanceof Error) return err.message;
-		if (typeof err === 'string') return err;
-		if (err && typeof err === 'object' && 'message' in err) {
-			const message = (err as { message?: string }).message;
-			if (typeof message === 'string') return message;
-		}
-		return fallback;
-	};
-
 	const loadInfo = async (): Promise<void> => {
 		loading = true;
 		error = null;
@@ -52,7 +43,7 @@
 				}, 1500);
 			}
 		} catch (err) {
-			error = formatError(err, 'Failed to load GitHub auth status.');
+			error = toErrorMessage(err, 'Failed to load GitHub auth status.');
 		} finally {
 			loading = false;
 		}
@@ -68,7 +59,7 @@
 			statusMessage =
 				next === 'cli' ? 'Using GitHub CLI for authentication.' : 'Using a personal access token.';
 		} catch (err) {
-			error = formatError(err, 'Failed to update GitHub auth mode.');
+			error = toErrorMessage(err, 'Failed to update GitHub auth mode.');
 		} finally {
 			saving = false;
 		}
@@ -91,7 +82,7 @@
 				? `Connected as ${info.status.login}.`
 				: 'GitHub token saved.';
 		} catch (err) {
-			error = formatError(err, 'Failed to save token.');
+			error = toErrorMessage(err, 'Failed to save token.');
 		} finally {
 			saving = false;
 		}
@@ -113,7 +104,7 @@
 				? 'GitHub CLI path saved.'
 				: 'Path saved. GitHub CLI still not detected.';
 		} catch (err) {
-			error = formatError(err, 'Failed to save GitHub CLI path.');
+			error = toErrorMessage(err, 'Failed to save GitHub CLI path.');
 		} finally {
 			saving = false;
 		}
@@ -128,7 +119,7 @@
 			cliPath = selected;
 			await saveCLIPath();
 		} catch (err) {
-			error = formatError(err, 'Failed to open file dialog.');
+			error = toErrorMessage(err, 'Failed to open file dialog.');
 		}
 	};
 
@@ -142,7 +133,7 @@
 			info = await fetchGitHubAuthInfo();
 			statusMessage = 'Token removed.';
 		} catch (err) {
-			error = formatError(err, 'Failed to remove token.');
+			error = toErrorMessage(err, 'Failed to remove token.');
 		} finally {
 			saving = false;
 		}

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/GroupManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/GroupManager.svelte
@@ -11,6 +11,7 @@
 		updateGroup,
 	} from '../../../api';
 	import type { Alias, Group, GroupSummary } from '../../../types';
+	import { toErrorMessage } from '../../../errors';
 	import SettingsSection from '../SettingsSection.svelte';
 	import GroupMemberRow from './GroupMemberRow.svelte';
 	import Button from '../../ui/Button.svelte';
@@ -35,18 +36,13 @@
 	let addingMember = $state(false);
 	let memberRepo = $state('');
 
-	const formatError = (err: unknown): string => {
-		if (err instanceof Error) return err.message;
-		return 'An error occurred.';
-	};
-
 	const loadGroups = async (): Promise<void> => {
 		try {
 			groups = await listGroups();
 			aliases = await listAliases();
 			onGroupCountChange(groups.length);
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 
@@ -60,7 +56,7 @@
 			error = null;
 			success = null;
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 
@@ -114,7 +110,7 @@
 				await selectGroup(summary);
 			}
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -141,7 +137,7 @@
 				formDescription = '';
 			}
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -181,7 +177,7 @@
 			selectedGroup = await getGroup(selectedGroup.name);
 			addingMember = false;
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -199,7 +195,7 @@
 			success = `Removed ${repo}.`;
 			selectedGroup = await getGroup(selectedGroup.name);
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}

--- a/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
+++ b/wails-ui/workset/frontend/src/lib/components/settings/sections/SkillManager.svelte
@@ -2,6 +2,7 @@
 	import { listSkills, getSkill, saveSkill, deleteSkill, syncSkill } from '../../../api';
 	import type { SkillInfo } from '../../../api';
 	import { activeWorkspace } from '../../../state';
+	import { toErrorMessage } from '../../../errors';
 	import SettingsSection from '../SettingsSection.svelte';
 	import Button from '../../ui/Button.svelte';
 
@@ -52,17 +53,12 @@
 
 	const getWorkspaceId = (): string | undefined => $activeWorkspace?.id;
 
-	const formatError = (err: unknown): string => {
-		if (err instanceof Error) return err.message;
-		return 'An error occurred.';
-	};
-
 	const loadSkills = async (): Promise<void> => {
 		try {
 			skills = await listSkills(getWorkspaceId());
 			onSkillCountChange(skills.length);
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 
@@ -84,7 +80,7 @@
 			formContent = result.content;
 		} catch (err) {
 			formContent = '';
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		}
 	};
 
@@ -158,7 +154,7 @@
 					editing = false;
 				}
 			} catch (err) {
-				error = formatError(err);
+				error = toErrorMessage(err, 'An error occurred.');
 			} finally {
 				loading = false;
 			}
@@ -184,7 +180,7 @@
 					selectedSkill = updated;
 				}
 			} catch (err) {
-				error = formatError(err);
+				error = toErrorMessage(err, 'An error occurred.');
 			} finally {
 				loading = false;
 			}
@@ -210,7 +206,7 @@
 			editing = false;
 			await loadSkills();
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -264,7 +260,7 @@
 				await selectSkill(updated);
 			}
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}
@@ -306,7 +302,7 @@
 				}
 			}
 		} catch (err) {
-			error = formatError(err);
+			error = toErrorMessage(err, 'An error occurred.');
 		} finally {
 			loading = false;
 		}

--- a/wails-ui/workset/frontend/src/lib/errors.test.ts
+++ b/wails-ui/workset/frontend/src/lib/errors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { toErrorMessage } from './errors';
+
+describe('toErrorMessage', () => {
+	test('returns Error message', () => {
+		expect(toErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+	});
+
+	test('returns string rejection reason', () => {
+		expect(toErrorMessage('request timed out', 'fallback')).toBe('request timed out');
+	});
+
+	test('returns object message field', () => {
+		expect(toErrorMessage({ message: 'service unavailable' }, 'fallback')).toBe(
+			'service unavailable',
+		);
+	});
+
+	test('returns fallback for unknown shapes', () => {
+		expect(toErrorMessage({ code: 503 }, 'fallback')).toBe('fallback');
+		expect(toErrorMessage('', 'fallback')).toBe('fallback');
+	});
+});

--- a/wails-ui/workset/frontend/src/lib/errors.ts
+++ b/wails-ui/workset/frontend/src/lib/errors.ts
@@ -1,0 +1,18 @@
+export const toErrorMessage = (
+	err: unknown,
+	fallback = 'An unexpected error occurred.',
+): string => {
+	if (err instanceof Error && err.message.trim() !== '') {
+		return err.message;
+	}
+	if (typeof err === 'string' && err.trim() !== '') {
+		return err;
+	}
+	if (err && typeof err === 'object' && 'message' in err) {
+		const message = (err as { message?: unknown }).message;
+		if (typeof message === 'string' && message.trim() !== '') {
+			return message;
+		}
+	}
+	return fallback;
+};


### PR DESCRIPTION
## Summary
- Added a shared `toErrorMessage` helper in `wails-ui/workset/frontend/src/lib/errors.ts` to standardize unknown error normalization with fallbacks.
- Replaced duplicated local `formatError` helpers across settings components (`SettingsPanel`, `AgentDefaults`, `AliasManager`, `GitHubAuth`, `GroupManager`, `SkillManager`) with the shared utility.
- Updated update-related error paths in `SettingsPanel` so backend-provided string/object messages are surfaced instead of being masked by generic fallback text.

## Tests
- Added unit tests for `toErrorMessage` in `wails-ui/workset/frontend/src/lib/errors.test.ts`.
- Added Settings About panel coverage in `wails-ui/workset/frontend/src/lib/components/settings/SettingsPanel.about.spec.ts` to verify string and object backend errors are displayed for failed update checks.